### PR TITLE
phase-1/pre: pre-sprint cleanup and CI gate baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,29 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  docs-consistency:
+    name: docs-consistency (ubuntu)
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate docs consistency
+        run: bash scripts/ci/validate_docs_consistency.sh
+
+  dependency-bans:
+    name: dependency-bans (ubuntu)
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate dependency bans
+        run: bash scripts/ci/validate_dependency_bans.sh
+
   manifest-validation:
     name: manifest-validation (ubuntu)
-    needs: [clippy]
+    needs: [clippy, docs-consistency, dependency-bans]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +91,12 @@ jobs:
 
       - name: Validate publish_order dependency graph
         run: bash scripts/ci/validate_publish_order.sh
+
+      - name: Validate docs consistency
+        run: bash scripts/ci/validate_docs_consistency.sh
+
+      - name: Validate dependency bans
+        run: bash scripts/ci/validate_dependency_bans.sh
 
       - name: Validate repo boundaries
         run: bash scripts/ci/validate_repo_boundaries.sh

--- a/crates/sc-observability-otlp/src/lib.rs
+++ b/crates/sc-observability-otlp/src/lib.rs
@@ -297,14 +297,17 @@ impl Telemetry {
 }
 
 mod sealed_emitters {
+    #[allow(dead_code)]
     pub trait Sealed {}
 }
 
-pub trait SpanEmitter: sealed_emitters::Sealed + Send + Sync {
+#[allow(dead_code)]
+pub(crate) trait SpanEmitter: sealed_emitters::Sealed + Send + Sync {
     fn emit_span(&self, span: SpanSignal) -> Result<(), TelemetryError>;
 }
 
-pub trait MetricEmitter: sealed_emitters::Sealed + Send + Sync {
+#[allow(dead_code)]
+pub(crate) trait MetricEmitter: sealed_emitters::Sealed + Send + Sync {
     fn emit_metric(&self, metric: MetricRecord) -> Result<(), TelemetryError>;
 }
 

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -168,10 +168,12 @@ impl Logger {
 }
 
 mod sealed_emitters {
+    #[allow(dead_code)]
     pub trait Sealed {}
 }
 
-pub trait LogEmitter: sealed_emitters::Sealed + Send + Sync {
+#[allow(dead_code)]
+pub(crate) trait LogEmitter: sealed_emitters::Sealed + Send + Sync {
     fn emit_log(&self, event: LogEvent) -> Result<(), EventError>;
 }
 

--- a/crates/sc-observe/src/lib.rs
+++ b/crates/sc-observe/src/lib.rs
@@ -136,13 +136,15 @@ impl ObservabilityBuilder {
 }
 
 mod sealed_emitters {
+    #[allow(dead_code)]
     pub trait Sealed {}
 }
 
 /// ObservationEmitter<T> is intentionally per-type -- callers hold one handle
 /// per observation type. A single type-erased emitter for heterogeneous events
 /// is not supported by design.
-pub trait ObservationEmitter<T>: sealed_emitters::Sealed + Send + Sync
+#[allow(dead_code)]
+pub(crate) trait ObservationEmitter<T>: sealed_emitters::Sealed + Send + Sync
 where
     T: Observable,
 {

--- a/docs/phase-1-sprint-assignment.md
+++ b/docs/phase-1-sprint-assignment.md
@@ -35,6 +35,12 @@ These should land before Sprint 1 starts:
 - docs consistency checks
 - dependency-ban enforcement
 
+Status:
+- implemented in this branch via:
+  - `scripts/ci/validate_docs_consistency.sh`
+  - `scripts/ci/validate_dependency_bans.sh`
+  - `.github/workflows/ci.yml`
+
 ## 3. Sprint Assignment By Milestone
 
 ### Sprint 1 / M0-M1: `sc-observability-types`
@@ -180,12 +186,10 @@ Required integration layers across the phase:
 
 ### Blockers
 
-1. The required Sprint 1 CI gates for docs consistency and dependency-ban
-   enforcement are documented but do not appear to be implemented yet in
-   `scripts/ci/` or `.github/workflows/ci.yml`.
-
-2. The pre-Sprint cleanup items above are still open in this worktree and
-   should be completed before Sprint 1 begins.
+1. Sprint 1 should use the concrete execution packet in
+   [`sprint-1-execution-packet.md`](./sprint-1-execution-packet.md) as the
+   controlling task breakdown so implementation does not drift from the phase
+   assignment.
 
 ### Questions
 

--- a/docs/public-api-checklist.md
+++ b/docs/public-api-checklist.md
@@ -175,8 +175,8 @@ Internal-only:
 
 Internal-only:
 
-- `SpanEmitter`
-- `MetricEmitter`
+- [~] `SpanEmitter`
+- [~] `MetricEmitter`
 
 Note:
 - sealed/crate-local per `architecture.md` §3.4 and OTLP-022

--- a/docs/sprint-1-execution-packet.md
+++ b/docs/sprint-1-execution-packet.md
@@ -1,0 +1,118 @@
+# Sprint 1 Execution Packet
+
+**Sprint**: Phase 1 / Sprint 1
+**Milestone**: M0-M1
+**Crate focus**: `sc-observability-types`
+**Depends on**:
+- pre-Sprint cleanup complete
+- docs consistency checks green
+- dependency-ban enforcement green
+
+## 1. Scope
+
+Sprint 1 turns `sc-observability-types` from a compileable skeleton into the
+first implementation-ready layer.
+
+This sprint covers:
+- workspace baseline confirmation for the 4-crate stack
+- validated value/newtype constructors
+- diagnostics and remediation surfaces
+- trace/span/observation contracts
+- shared health types
+- shared open traits
+- serialization and lifecycle tests for the public contract layer
+
+This sprint does not cover:
+- real sink behavior
+- observation routing/runtime behavior
+- OTLP/export behavior
+- ATM production adapter behavior
+
+## 2. Files And Modules
+
+Expected implementation touch points:
+- `crates/sc-observability-types/src/lib.rs`
+- `crates/sc-observability-types/src/constants.rs`
+- `crates/sc-observability-types/src/error_codes.rs`
+- `crates/sc-observability-types/Cargo.toml`
+
+Expected supporting updates:
+- `docs/public-api-checklist.md`
+- `docs/implementation-plan.md`
+- `docs/test-strategy.md`
+
+## 3. Deliverables
+
+### M0 Workspace Baseline
+
+- all four crates present as workspace members
+- dependency order remains:
+  `sc-observability-types <- sc-observability <- sc-observe <- sc-observability-otlp`
+- shared constants and error-code modules remain single-source-of-truth
+
+### M1 `sc-observability-types`
+
+- complete constructors and validation for:
+  - `ToolName`
+  - `EnvPrefix`
+  - `ServiceName`
+  - `TargetCategory`
+  - `ActionName`
+  - `MetricName`
+  - `TraceId`
+  - `SpanId`
+- complete remediation and diagnostic surfaces:
+  - `ErrorCode`
+  - `RecoverableSteps`
+  - `Remediation`
+  - `Diagnostic`
+  - `DiagnosticSummary`
+  - `ErrorContext`
+- complete observation and telemetry-neutral contracts:
+  - `Observation<T>`
+  - `LogEvent`
+  - `SpanRecord<S>`
+  - `SpanEvent`
+  - `SpanSignal`
+  - `MetricRecord`
+  - `TraceContext`
+  - `StateTransition`
+- complete shared health models and open traits
+
+## 4. Required Tests
+
+Required Sprint 1 tests:
+- validation tests for all name newtypes
+- `TraceId` and `SpanId` validation tests
+- remediation construction tests
+- `ErrorContext` rendering tests
+- serde round-trip tests for:
+  - `Diagnostic`
+  - `Observation<T>` with fixture payloads
+  - `LogEvent`
+  - `SpanSignal`
+  - `MetricRecord`
+- typestate tests for `SpanRecord<SpanStarted>::end(...)`
+
+## 5. Exit Criteria
+
+Sprint 1 is complete only when:
+- `cargo fmt --check`
+- `cargo check --workspace --all-targets`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `bash scripts/ci/validate_docs_consistency.sh`
+- `bash scripts/ci/validate_dependency_bans.sh`
+- `bash scripts/ci/validate_repo_boundaries.sh`
+
+And:
+- no placeholder fields remain in the finalized `sc-observability-types` API
+- `docs/public-api-checklist.md` reflects the Sprint 1 public surface accurately
+- `sc-observability-types` API freeze gate is ready for review at sprint close
+
+## 6. Do-Not-Start Conditions
+
+Do not start Sprint 2 until Sprint 1 has:
+- green CI on the required gates above
+- updated docs/checklist alignment
+- no unresolved public API questions on the `sc-observability-types` surface

--- a/scripts/ci/validate_dependency_bans.sh
+++ b/scripts/ci/validate_dependency_bans.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+import tomllib
+
+root = Path(".")
+
+def load_toml(path: Path):
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+def package_deps(path: Path):
+    data = load_toml(path)
+    names = set()
+    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+        names.update(data.get(section, {}).keys())
+    return names
+
+workspace = load_toml(root / "Cargo.toml")
+members = set(workspace["workspace"]["members"])
+required_members = {
+    "crates/sc-observability-types",
+    "crates/sc-observability",
+    "crates/sc-observe",
+    "crates/sc-observability-otlp",
+}
+
+missing = required_members - members
+if missing:
+    raise SystemExit(f"missing workspace members: {sorted(missing)}")
+
+for path in root.rglob("Cargo.toml"):
+    text = path.read_text(encoding="utf-8")
+    if "agent-team-mail-" in text or "agent_team_mail" in text:
+        raise SystemExit(f"ATM dependency reference found in {path}")
+
+obs_deps = package_deps(root / "crates/sc-observability/Cargo.toml")
+observe_deps = package_deps(root / "crates/sc-observe/Cargo.toml")
+otlp_deps = package_deps(root / "crates/sc-observability-otlp/Cargo.toml")
+
+if obs_deps != {"serde_json", "sc-observability-types"}:
+    raise SystemExit(
+        "sc-observability dependency set drifted from allowed baseline: "
+        f"{sorted(obs_deps)}"
+    )
+
+if observe_deps != {"sc-observability-types", "sc-observability"}:
+    raise SystemExit(
+        "sc-observe dependency set drifted from allowed baseline: "
+        f"{sorted(observe_deps)}"
+    )
+
+required_otlp = {"serde_json", "thiserror", "sc-observability-types", "sc-observe"}
+if otlp_deps != required_otlp:
+    raise SystemExit(
+        "sc-observability-otlp dependency set drifted from allowed baseline: "
+        f"{sorted(otlp_deps)}"
+    )
+
+for path in [
+    root / "crates/sc-observability-types/Cargo.toml",
+    root / "crates/sc-observability/Cargo.toml",
+    root / "crates/sc-observe/Cargo.toml",
+]:
+    deps = package_deps(path)
+    if any(name.startswith("opentelemetry") or "otlp" in name for name in deps):
+        raise SystemExit(f"OTLP/OpenTelemetry dependency found outside sc-observability-otlp: {path}")
+
+print("dependency ban validation passed")
+PY

--- a/scripts/ci/validate_docs_consistency.sh
+++ b/scripts/ci/validate_docs_consistency.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+root = Path(".")
+requirements = (root / "docs/requirements.md").read_text(encoding="utf-8")
+architecture = (root / "docs/architecture.md").read_text(encoding="utf-8")
+api_design = (root / "docs/api-design.md").read_text(encoding="utf-8")
+phase_plan = (root / "docs/phase-1-sprint-assignment.md").read_text(encoding="utf-8")
+
+expected_stack = "sc-observability-types\n  <- sc-observability\n    <- sc-observe\n      <- sc-observability-otlp"
+if expected_stack not in requirements:
+    raise SystemExit("requirements.md missing canonical layered dependency order")
+
+architecture_checks = [
+    "sc-observability-types\n  shared neutral contracts only",
+    "sc-observability\n  lightweight logging only",
+    "sc-observe\n  observation routing / pub-sub / projection",
+    "sc-observability-otlp\n  OpenTelemetry / OTLP integration",
+    "`TelemetryConfig` is constructed and owned by the application layer",
+    "`sc-observability-otlp` registers its `LogProjector`, `SpanProjector`, and",
+    "atm-observability-adapter",
+]
+for needle in architecture_checks:
+    if needle not in architecture:
+        raise SystemExit(f"architecture.md missing consistency marker: {needle!r}")
+
+api_checks = [
+    "sc-observability-types <- sc-observability <- sc-observe <- sc-observability-otlp",
+    "`sc-observe` does not derive or own `TelemetryConfig`",
+    "`TelemetryConfig` is constructed independently by the application layer and",
+    "`sc-observability-otlp` attaches to the routing layer by registering its",
+]
+for needle in api_checks:
+    if needle not in api_design:
+        raise SystemExit(f"api-design.md missing consistency marker: {needle!r}")
+
+required_ids = ["LAY-004", "OTLP-017", "OTLP-018", "NFR-009", "NFR-010"]
+for req_id in required_ids:
+    if req_id not in requirements:
+        raise SystemExit(f"requirements.md missing required rule: {req_id}")
+
+phase_checks = [
+    "Sprint 5: Working ATM Adapter Example",
+    "Sprint 6: Hardening And Release Readiness",
+    "docs consistency checks",
+    "dependency-ban enforcement",
+]
+for needle in phase_checks:
+    if needle not in phase_plan:
+        raise SystemExit(f"phase-1-sprint-assignment.md missing consistency marker: {needle!r}")
+
+print("docs consistency validation passed")
+PY


### PR DESCRIPTION
## Sprint

**OBS-PHASE-1-PRE** — Pre-Sprint-1 cleanup

## Summary

- Sealed emitter traits changed to `pub(crate)` in all three implementation crates (`LogEmitter`, `ObservationEmitter<T>`, `SpanEmitter`, `MetricEmitter`)
- `[~]` markers added to `SpanEmitter` and `MetricEmitter` in `docs/public-api-checklist.md` §5 internal-only list
- `scripts/ci/validate_docs_consistency.sh` implemented and wired into `.github/workflows/ci.yml`
- `scripts/ci/validate_dependency_bans.sh` implemented and wired into `.github/workflows/ci.yml`
- Phase-1 sprint assignment doc updated to mark pre-sprint gate work as complete
- `docs/sprint-1-execution-packet.md` added

## Acceptance Criteria

- [ ] `LogEmitter`, `ObservationEmitter<T>`, `SpanEmitter`, `MetricEmitter` are `pub(crate)`
- [ ] Checklist §5 `SpanEmitter`/`MetricEmitter` use `[~]` markers
- [ ] CI runs docs-consistency and dependency-ban checks
- [ ] `cargo fmt --check` passes
- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] `bash scripts/ci/validate_repo_boundaries.sh` passes

## References

- `docs/phase-1-sprint-assignment.md`
- `docs/test-strategy.md` §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)