### PR TITLE
phase-1/s1: sc-observability-types (M0+M1)

### DIFF
--- a/crates/sc-observability-types/src/constants.rs
+++ b/crates/sc-observability-types/src/constants.rs
@@ -1,4 +1,10 @@
+//! Shared cross-crate constants owned by `sc-observability-types`.
+
+/// Current version string for the observation envelope contract.
 pub const OBSERVATION_ENVELOPE_VERSION: &str = "v1";
+/// Required character length for W3C trace identifiers.
 pub const TRACE_ID_LEN: usize = 32;
+/// Required character length for W3C span identifiers.
 pub const SPAN_ID_LEN: usize = 16;
+/// Separator used when deriving environment prefixes.
 pub const DEFAULT_ENV_PREFIX_SEPARATOR: char = '_';

--- a/crates/sc-observability-types/src/error_codes.rs
+++ b/crates/sc-observability-types/src/error_codes.rs
@@ -1,16 +1,24 @@
+//! Stable `ErrorCode` registry for `sc-observability-types`.
+
 use crate::ErrorCode;
 
+/// Generic validation error code used for shared value-type failures.
 pub const VALUE_VALIDATION_FAILED: ErrorCode =
     ErrorCode::new_static("SC_OBSERVABILITY_TYPES_VALUE_VALIDATION_FAILED");
+/// Error code for invalid W3C trace identifier values.
 pub const TRACE_ID_INVALID: ErrorCode =
     ErrorCode::new_static("SC_OBSERVABILITY_TYPES_TRACE_ID_INVALID");
+/// Error code for invalid W3C span identifier values.
 pub const SPAN_ID_INVALID: ErrorCode =
     ErrorCode::new_static("SC_OBSERVABILITY_TYPES_SPAN_ID_INVALID");
+/// Error code for process identity resolution failures.
 pub const IDENTITY_RESOLUTION_FAILED: ErrorCode =
     ErrorCode::new_static("SC_OBSERVABILITY_TYPES_IDENTITY_RESOLUTION_FAILED");
+/// Error code for generic diagnostic construction or validation failures.
 pub const DIAGNOSTIC_INVALID: ErrorCode =
     ErrorCode::new_static("SC_OBSERVABILITY_TYPES_DIAGNOSTIC_INVALID");
 
+/// Enumerable registry of all public `sc-observability-types` error codes.
 pub const ALL: &[ErrorCode] = &[
     VALUE_VALIDATION_FAILED,
     TRACE_ID_INVALID,

--- a/crates/sc-observability-types/src/lib.rs
+++ b/crates/sc-observability-types/src/lib.rs
@@ -1,3 +1,10 @@
+//! Shared neutral contracts for the `sc-observability` workspace.
+//!
+//! This crate defines the reusable value types, diagnostics, typestate span
+//! contracts, health reports, and open extension traits consumed by the higher
+//! layers in the workspace. It intentionally avoids owning sinks, routing
+//! runtimes, exporter behavior, or ATM-specific payload types.
+
 pub mod constants;
 pub mod error_codes;
 
@@ -10,8 +17,10 @@ use serde_json::{Map, Value};
 use thiserror::Error;
 use time::OffsetDateTime;
 
+/// Canonical UTC timestamp type used across the workspace.
 pub type Timestamp = OffsetDateTime;
 
+/// Stable machine-readable error code used across diagnostics and error types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ErrorCode(Cow<'static, str>);
 
@@ -29,17 +38,34 @@ impl ErrorCode {
     }
 }
 
+/// Validation error returned when a public value type rejects an input.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 #[error("{message}")]
 pub struct ValueValidationError {
+    code: ErrorCode,
     message: String,
 }
 
 impl ValueValidationError {
+    /// Creates a validation error using the default shared validation code.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
+            code: error_codes::VALUE_VALIDATION_FAILED,
             message: message.into(),
         }
+    }
+
+    /// Creates a validation error with an explicit stable error code.
+    pub fn with_code(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Returns the stable error code associated with the validation failure.
+    pub fn code(&self) -> &ErrorCode {
+        &self.code
     }
 }
 
@@ -147,21 +173,39 @@ validated_name_type!(
     validate_metric_name
 );
 
+/// Ordered recovery steps for a recoverable diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecoverableSteps {
     steps: Vec<String>,
 }
 
 impl RecoverableSteps {
-    pub fn first(&self) -> Option<&str> {
+    /// Creates a recoverable step list containing exactly one first action.
+    pub fn first(step: impl Into<String>) -> Self {
+        Self {
+            steps: vec![step.into()],
+        }
+    }
+
+    /// Creates a recoverable step list from a full ordered set of actions.
+    pub fn all(steps: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            steps: steps.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Returns the first recommended recovery step, if present.
+    pub fn first_step(&self) -> Option<&str> {
         self.steps.first().map(String::as_str)
     }
 
-    pub fn all(&self) -> &[String] {
+    /// Returns all ordered recovery steps.
+    pub fn steps(&self) -> &[String] {
         &self.steps
     }
 }
 
+/// Required remediation metadata attached to every diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Remediation {
@@ -175,11 +219,9 @@ impl Remediation {
         rest: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         let mut steps = vec![first.into()];
-        for value in rest {
-            steps.push(value.into());
-        }
+        steps.extend(rest.into_iter().map(Into::into));
         Self::Recoverable {
-            steps: RecoverableSteps { steps },
+            steps: RecoverableSteps::all(steps),
         }
     }
 
@@ -190,6 +232,7 @@ impl Remediation {
     }
 }
 
+/// Structured diagnostic payload reusable across CLI, logging, and telemetry.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Diagnostic {
     pub code: ErrorCode,
@@ -203,10 +246,12 @@ pub struct Diagnostic {
     pub details: Map<String, Value>,
 }
 
+/// Trait for public error surfaces that can expose an attached diagnostic.
 pub trait DiagnosticInfo {
     fn diagnostic(&self) -> &Diagnostic;
 }
 
+/// Small diagnostic summary used in health and last-error reporting.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DiagnosticSummary {
     pub code: Option<ErrorCode>,
@@ -224,6 +269,7 @@ impl From<&Diagnostic> for DiagnosticSummary {
     }
 }
 
+/// Builder-style context wrapper used by public crate error types.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ErrorContext {
     diagnostic: Diagnostic,
@@ -281,6 +327,7 @@ impl std::fmt::Display for ErrorContext {
     }
 }
 
+/// Error returned when process identity resolution fails.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Error)]
 #[error("{0}")]
 pub struct IdentityError(pub Box<ErrorContext>);
@@ -291,6 +338,7 @@ impl DiagnosticInfo for IdentityError {
     }
 }
 
+/// Canonical event/log severity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Level {
     Trace,
@@ -300,6 +348,7 @@ pub enum Level {
     Error,
 }
 
+/// Level threshold used by filtering surfaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LevelFilter {
     Trace,
@@ -310,12 +359,14 @@ pub enum LevelFilter {
     Off,
 }
 
+/// Caller-resolved process identity attached to observations and log events.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ProcessIdentity {
     pub hostname: Option<String>,
     pub pid: Option<u32>,
 }
 
+/// Policy describing how process identity is populated at runtime.
 pub enum ProcessIdentityPolicy {
     Auto,
     Fixed {
@@ -325,10 +376,12 @@ pub enum ProcessIdentityPolicy {
     Resolver(Arc<dyn ProcessIdentityResolver>),
 }
 
+/// Open resolver contract for caller-defined process identity lookup.
 pub trait ProcessIdentityResolver: Send + Sync {
     fn resolve(&self) -> Result<ProcessIdentity, IdentityError>;
 }
 
+/// Validated 32-character lowercase hexadecimal trace identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TraceId(String);
 
@@ -338,7 +391,7 @@ impl TraceId {
         validate_lower_hex(
             &value,
             constants::TRACE_ID_LEN,
-            error_codes::TRACE_ID_INVALID.as_str(),
+            &error_codes::TRACE_ID_INVALID,
         )?;
         Ok(Self(value))
     }
@@ -348,6 +401,7 @@ impl TraceId {
     }
 }
 
+/// Validated 16-character lowercase hexadecimal span identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SpanId(String);
 
@@ -357,7 +411,7 @@ impl SpanId {
         validate_lower_hex(
             &value,
             constants::SPAN_ID_LEN,
-            error_codes::SPAN_ID_INVALID.as_str(),
+            &error_codes::SPAN_ID_INVALID,
         )?;
         Ok(Self(value))
     }
@@ -370,12 +424,13 @@ impl SpanId {
 fn validate_lower_hex(
     value: &str,
     expected_len: usize,
-    _code: &str,
+    code: &ErrorCode,
 ) -> Result<(), ValueValidationError> {
     if value.len() != expected_len {
-        return Err(ValueValidationError::new(format!(
-            "value must be {expected_len} lowercase hex characters"
-        )));
+        return Err(ValueValidationError::with_code(
+            code.clone(),
+            format!("value must be {expected_len} lowercase hex characters"),
+        ));
     }
     if value
         .chars()
@@ -383,12 +438,14 @@ fn validate_lower_hex(
     {
         Ok(())
     } else {
-        Err(ValueValidationError::new(
+        Err(ValueValidationError::with_code(
+            code.clone(),
             "value must contain lowercase hex characters only",
         ))
     }
 }
 
+/// Generic trace correlation context shared by logs, spans, and observations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceContext {
     pub trace_id: TraceId,
@@ -396,6 +453,7 @@ pub struct TraceContext {
     pub parent_span_id: Option<SpanId>,
 }
 
+/// Typed description of an entity moving from one state to another.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateTransition {
     /// Stable category describing what changed, such as `task` or `subagent`.
@@ -412,10 +470,12 @@ pub struct StateTransition {
     pub trigger: Option<String>,
 }
 
+/// Marker trait for consumer-owned observation payloads.
 pub trait Observable: Send + Sync + 'static {}
 
 impl<T> Observable for T where T: Send + Sync + 'static {}
 
+/// Shared envelope around a typed observation payload.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Observation<T>
 where
@@ -445,6 +505,7 @@ where
     }
 }
 
+/// Structured log record emitted by the logging and routing layers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LogEvent {
     pub version: String,
@@ -464,6 +525,7 @@ pub struct LogEvent {
     pub fields: Map<String, Value>,
 }
 
+/// Final span status for a completed span record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SpanStatus {
     Ok,
@@ -471,13 +533,16 @@ pub enum SpanStatus {
     Unset,
 }
 
+/// Typestate marker for a started-but-not-yet-ended span.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpanStarted;
 
+/// Typestate marker for a completed span.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpanEnded;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Producer-facing span record whose lifecycle is encoded via typestate.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SpanRecord<S> {
     timestamp: Timestamp,
     service: ServiceName,
@@ -491,6 +556,7 @@ pub struct SpanRecord<S> {
 }
 
 impl SpanRecord<SpanStarted> {
+    /// Creates a new started span record.
     pub fn new(
         timestamp: Timestamp,
         service: ServiceName,
@@ -511,11 +577,13 @@ impl SpanRecord<SpanStarted> {
         }
     }
 
+    /// Attaches a diagnostic to the started span before completion.
     pub fn with_diagnostic(mut self, diagnostic: Diagnostic) -> Self {
         self.diagnostic = Some(diagnostic);
         self
     }
 
+    /// Consumes the started span and returns the only valid completed span form.
     pub fn end(self, status: SpanStatus, duration_ms: u64) -> SpanRecord<SpanEnded> {
         SpanRecord {
             timestamp: self.timestamp,
@@ -532,41 +600,50 @@ impl SpanRecord<SpanStarted> {
 }
 
 impl<S> SpanRecord<S> {
+    /// Returns the timestamp recorded for the span lifecycle event.
     pub fn timestamp(&self) -> Timestamp {
         self.timestamp
     }
 
+    /// Returns the service that emitted the span.
     pub fn service(&self) -> &ServiceName {
         &self.service
     }
 
+    /// Returns the stable action/name associated with the span.
     pub fn name(&self) -> &ActionName {
         &self.name
     }
 
+    /// Returns the trace context for the span.
     pub fn trace(&self) -> &TraceContext {
         &self.trace
     }
 
+    /// Returns the current typestate-derived span status.
     pub fn status(&self) -> SpanStatus {
         self.status
     }
 
+    /// Returns the optional diagnostic attached to the span.
     pub fn diagnostic(&self) -> Option<&Diagnostic> {
         self.diagnostic.as_ref()
     }
 
+    /// Returns immutable span attributes.
     pub fn attributes(&self) -> &Map<String, Value> {
         &self.attributes
     }
 }
 
 impl SpanRecord<SpanEnded> {
+    /// Returns the final duration, available only on completed spans.
     pub fn duration_ms(&self) -> u64 {
         self.duration_ms.unwrap_or_default()
     }
 }
 
+/// Event attached to a span timeline without creating a child span.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpanEvent {
     pub timestamp: Timestamp,
@@ -576,13 +653,15 @@ pub struct SpanEvent {
     pub diagnostic: Option<Diagnostic>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Generic span lifecycle signal used by projectors and telemetry assembly.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum SpanSignal {
     Started(SpanRecord<SpanStarted>),
     Event(SpanEvent),
     Ended(SpanRecord<SpanEnded>),
 }
 
+/// Supported metric aggregation shapes.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum MetricKind {
     Counter,
@@ -590,6 +669,7 @@ pub enum MetricKind {
     Histogram,
 }
 
+/// Structured metric observation projected from routing or telemetry layers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricRecord {
     pub timestamp: Timestamp,
@@ -602,6 +682,7 @@ pub struct MetricRecord {
     pub attributes: Map<String, Value>,
 }
 
+/// Top-level health state for the lightweight logging layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LoggingHealthState {
     Healthy,
@@ -609,6 +690,7 @@ pub enum LoggingHealthState {
     Unavailable,
 }
 
+/// Health state for an individual log sink.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SinkHealthState {
     Healthy,
@@ -616,6 +698,7 @@ pub enum SinkHealthState {
     Unavailable,
 }
 
+/// Health summary for one concrete logging sink.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SinkHealth {
     pub name: String,
@@ -623,6 +706,7 @@ pub struct SinkHealth {
     pub last_error: Option<DiagnosticSummary>,
 }
 
+/// Aggregate logging health report.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingHealthReport {
     pub state: LoggingHealthState,
@@ -632,6 +716,7 @@ pub struct LoggingHealthReport {
     pub last_error: Option<DiagnosticSummary>,
 }
 
+/// Top-level health state for the observation routing runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ObservationHealthState {
     Healthy,
@@ -639,6 +724,7 @@ pub enum ObservationHealthState {
     Unavailable,
 }
 
+/// Aggregate routing/runtime health report.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ObservabilityHealthReport {
     pub state: ObservationHealthState,
@@ -650,6 +736,7 @@ pub struct ObservabilityHealthReport {
     pub last_error: Option<DiagnosticSummary>,
 }
 
+/// Top-level health state for telemetry export.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TelemetryHealthState {
     Disabled,
@@ -658,6 +745,7 @@ pub enum TelemetryHealthState {
     Unavailable,
 }
 
+/// Health state for an individual telemetry exporter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExporterHealthState {
     Healthy,
@@ -665,6 +753,7 @@ pub enum ExporterHealthState {
     Unavailable,
 }
 
+/// Health summary for one configured telemetry exporter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExporterHealth {
     pub name: String,
@@ -672,6 +761,7 @@ pub struct ExporterHealth {
     pub last_error: Option<DiagnosticSummary>,
 }
 
+/// Aggregate telemetry/export health report.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TelemetryHealthReport {
     pub state: TelemetryHealthState,
@@ -680,6 +770,7 @@ pub struct TelemetryHealthReport {
     pub last_error: Option<DiagnosticSummary>,
 }
 
+/// Open subscriber contract for typed observations.
 pub trait ObservationSubscriber<T>: Send + Sync
 where
     T: Observable,
@@ -687,6 +778,7 @@ where
     fn handle(&self, observation: &Observation<T>) -> Result<(), SubscriberError>;
 }
 
+/// Open filter contract evaluated before subscriber or projector execution.
 pub trait ObservationFilter<T>: Send + Sync
 where
     T: Observable,
@@ -694,6 +786,7 @@ where
     fn accepts(&self, observation: &Observation<T>) -> bool;
 }
 
+/// Open projector contract from typed observations into log events.
 pub trait LogProjector<T>: Send + Sync
 where
     T: Observable,
@@ -701,6 +794,7 @@ where
     fn project_logs(&self, observation: &Observation<T>) -> Result<Vec<LogEvent>, ProjectionError>;
 }
 
+/// Open projector contract from typed observations into span signals.
 pub trait SpanProjector<T>: Send + Sync
 where
     T: Observable,
@@ -711,6 +805,7 @@ where
     ) -> Result<Vec<SpanSignal>, ProjectionError>;
 }
 
+/// Open projector contract from typed observations into metric records.
 pub trait MetricProjector<T>: Send + Sync
 where
     T: Observable,
@@ -721,6 +816,7 @@ where
     ) -> Result<Vec<MetricRecord>, ProjectionError>;
 }
 
+/// Construction-time registration for one typed observation subscriber.
 #[derive(Clone)]
 pub struct SubscriberRegistration<T>
 where
@@ -730,6 +826,7 @@ where
     pub filter: Option<Arc<dyn ObservationFilter<T>>>,
 }
 
+/// Construction-time registration for log/span/metric projection of a payload.
 #[derive(Clone)]
 pub struct ProjectionRegistration<T>
 where
@@ -742,7 +839,8 @@ where
 }
 
 macro_rules! error_wrapper {
-    ($name:ident) => {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Error)]
         #[error("{0}")]
         pub struct $name(pub Box<ErrorContext>);
@@ -755,15 +853,40 @@ macro_rules! error_wrapper {
     };
 }
 
-error_wrapper!(InitError);
-error_wrapper!(EventError);
-error_wrapper!(FlushError);
-error_wrapper!(ShutdownError);
-error_wrapper!(ProjectionError);
-error_wrapper!(SubscriberError);
-error_wrapper!(LogSinkError);
-error_wrapper!(ExportError);
+error_wrapper!(
+    /// Initialization error returned by public construction entry points.
+    InitError
+);
+error_wrapper!(
+    /// Event validation or lifecycle error returned during emit paths.
+    EventError
+);
+error_wrapper!(
+    /// Flush error returned by explicit flush operations.
+    FlushError
+);
+error_wrapper!(
+    /// Shutdown error returned when graceful shutdown fails.
+    ShutdownError
+);
+error_wrapper!(
+    /// Projection error returned by log/span/metric projectors.
+    ProjectionError
+);
+error_wrapper!(
+    /// Subscriber error returned by observation subscribers.
+    SubscriberError
+);
+error_wrapper!(
+    /// Logging sink error returned by concrete sink implementations.
+    LogSinkError
+);
+error_wrapper!(
+    /// Export error returned by concrete telemetry exporters.
+    ExportError
+);
 
+/// Routing/runtime error returned by `Observability::emit`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Error)]
 pub enum ObservationError {
     #[error("observation runtime is shut down")]
@@ -774,6 +897,7 @@ pub enum ObservationError {
     RoutingFailure(Box<ErrorContext>),
 }
 
+/// Telemetry emit error returned by `Telemetry` operations.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Error)]
 pub enum TelemetryError {
     #[error("telemetry runtime is shut down")]
@@ -834,6 +958,39 @@ mod tests {
     }
 
     #[test]
+    fn remediation_construction_helpers_cover_both_variants() {
+        let recoverable = Remediation::recoverable("fix the input", ["retry"]);
+        let not_recoverable = Remediation::not_recoverable("manual intervention required");
+        let first_only = RecoverableSteps::first("first");
+        let all_steps = RecoverableSteps::all(["first", "second"]);
+
+        match recoverable {
+            Remediation::Recoverable { steps } => {
+                assert_eq!(steps.first_step(), Some("fix the input"));
+                assert_eq!(
+                    steps.steps(),
+                    ["fix the input".to_string(), "retry".to_string()]
+                );
+            }
+            Remediation::NotRecoverable { .. } => panic!("expected recoverable remediation"),
+        }
+
+        match not_recoverable {
+            Remediation::NotRecoverable { justification } => {
+                assert_eq!(justification, "manual intervention required");
+            }
+            Remediation::Recoverable { .. } => panic!("expected non-recoverable remediation"),
+        }
+
+        assert_eq!(first_only.first_step(), Some("first"));
+        assert_eq!(first_only.steps(), ["first".to_string()]);
+        assert_eq!(
+            all_steps.steps(),
+            ["first".to_string(), "second".to_string()]
+        );
+    }
+
+    #[test]
     fn validated_name_newtypes_accept_expected_values() {
         assert_eq!(
             ToolName::new("codex-cli")
@@ -887,12 +1044,19 @@ mod tests {
     #[test]
     fn trace_and_span_ids_validate_w3c_shapes() {
         assert!(TraceId::new("0123456789abcdef0123456789abcdef").is_ok());
-        assert!(TraceId::new("0123456789abcdef0123456789abcde").is_err());
-        assert!(TraceId::new("0123456789ABCDEF0123456789abcdef").is_err());
+        let short_trace = TraceId::new("0123456789abcdef0123456789abcde")
+            .expect_err("short trace id should fail");
+        assert_eq!(short_trace.code(), &error_codes::TRACE_ID_INVALID);
+        let uppercase_trace = TraceId::new("0123456789ABCDEF0123456789abcdef")
+            .expect_err("uppercase trace id should fail");
+        assert_eq!(uppercase_trace.code(), &error_codes::TRACE_ID_INVALID);
 
         assert!(SpanId::new("0123456789abcdef").is_ok());
-        assert!(SpanId::new("0123456789abcde").is_err());
-        assert!(SpanId::new("0123456789ABCDEf").is_err());
+        let short_span = SpanId::new("0123456789abcde").expect_err("short span id should fail");
+        assert_eq!(short_span.code(), &error_codes::SPAN_ID_INVALID);
+        let uppercase_span =
+            SpanId::new("0123456789ABCDEf").expect_err("uppercase span id should fail");
+        assert_eq!(uppercase_span.code(), &error_codes::SPAN_ID_INVALID);
     }
 
     #[test]
@@ -908,11 +1072,39 @@ mod tests {
     }
 
     #[test]
+    fn error_context_builder_sets_docs_details_and_source() {
+        let error = ErrorContext::new(
+            error_codes::DIAGNOSTIC_INVALID,
+            "operation failed",
+            Remediation::not_recoverable("investigate manually"),
+        )
+        .docs("https://example.test/failure")
+        .detail("attempt", json!(3))
+        .source(Box::new(std::io::Error::other("disk full")));
+
+        assert_eq!(
+            error.diagnostic().docs.as_deref(),
+            Some("https://example.test/failure")
+        );
+        assert_eq!(error.diagnostic().details.get("attempt"), Some(&json!(3)));
+        assert_eq!(error.source.as_deref(), Some("disk full"));
+    }
+
+    #[test]
     fn diagnostic_round_trips_through_serde() {
         let original = diagnostic();
         let encoded = serde_json::to_string(&original).expect("serialize diagnostic");
         let decoded: Diagnostic = serde_json::from_str(&encoded).expect("deserialize diagnostic");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn diagnostic_summary_captures_code_and_message() {
+        let summary = DiagnosticSummary::from(&diagnostic());
+
+        assert_eq!(summary.code, Some(error_codes::DIAGNOSTIC_INVALID));
+        assert_eq!(summary.message, "diagnostic invalid");
+        assert!(summary.at <= OffsetDateTime::now_utc());
     }
 
     #[test]
@@ -987,10 +1179,10 @@ mod tests {
 
         let ended = started.clone().end(SpanStatus::Ok, 123);
         let signal = SpanSignal::Ended(ended);
+        let encoded = serde_json::to_value(&signal).expect("serialize span signal");
 
-        let encoded = serde_json::to_string(&signal).expect("serialize span signal");
-        let decoded: SpanSignal = serde_json::from_str(&encoded).expect("deserialize span signal");
-        assert_eq!(decoded, signal);
+        assert_eq!(encoded["Ended"]["status"], "Ok");
+        assert_eq!(encoded["Ended"]["duration_ms"], 123);
     }
 
     #[test]
@@ -1025,5 +1217,84 @@ mod tests {
         assert_eq!(ended.status(), SpanStatus::Error);
         assert_eq!(ended.duration_ms(), 88);
         assert_eq!(ended.service().as_str(), "sc-observability");
+    }
+
+    #[test]
+    fn observation_new_sets_defaults() {
+        let observation = Observation::new(
+            service_name(),
+            FixturePayload {
+                name: "payload".to_string(),
+                count: 1,
+            },
+        );
+
+        assert_eq!(observation.version, constants::OBSERVATION_ENVELOPE_VERSION);
+        assert_eq!(observation.identity, ProcessIdentity::default());
+        assert!(observation.trace.is_none());
+    }
+
+    #[test]
+    fn span_record_accessors_preserve_started_values() {
+        let mut attributes = Map::new();
+        attributes.insert("count".to_string(), json!(2));
+        let span = SpanRecord::<SpanStarted>::new(
+            OffsetDateTime::UNIX_EPOCH,
+            service_name(),
+            action_name(),
+            trace_context(),
+            attributes.clone(),
+        )
+        .with_diagnostic(diagnostic());
+
+        assert_eq!(span.timestamp(), OffsetDateTime::UNIX_EPOCH);
+        assert_eq!(span.name().as_str(), "observation.received");
+        assert_eq!(
+            span.trace().trace_id.as_str(),
+            "0123456789abcdef0123456789abcdef"
+        );
+        assert_eq!(span.status(), SpanStatus::Unset);
+        assert_eq!(span.diagnostic(), Some(&diagnostic()));
+        assert_eq!(span.attributes(), &attributes);
+    }
+
+    #[test]
+    fn health_reports_round_trip_through_serde() {
+        let sink = SinkHealth {
+            name: "jsonl".to_string(),
+            state: SinkHealthState::Healthy,
+            last_error: Some(DiagnosticSummary::from(&diagnostic())),
+        };
+        let logging = LoggingHealthReport {
+            state: LoggingHealthState::Healthy,
+            dropped_events_total: 0,
+            active_log_path: std::path::PathBuf::from("/var/log/service/logs/service.log.jsonl"),
+            sink_statuses: vec![sink],
+            last_error: None,
+        };
+        let telemetry = TelemetryHealthReport {
+            state: TelemetryHealthState::Healthy,
+            dropped_exports_total: 1,
+            exporter_statuses: vec![ExporterHealth {
+                name: "otlp".to_string(),
+                state: ExporterHealthState::Degraded,
+                last_error: Some(DiagnosticSummary::from(&diagnostic())),
+            }],
+            last_error: Some(DiagnosticSummary::from(&diagnostic())),
+        };
+        let report = ObservabilityHealthReport {
+            state: ObservationHealthState::Degraded,
+            dropped_observations_total: 2,
+            subscriber_failures_total: 3,
+            projection_failures_total: 4,
+            logging: Some(logging),
+            telemetry: Some(telemetry),
+            last_error: Some(DiagnosticSummary::from(&diagnostic())),
+        };
+
+        let encoded = serde_json::to_string(&report).expect("serialize observability health");
+        let decoded: ObservabilityHealthReport =
+            serde_json::from_str(&encoded).expect("deserialize observability health");
+        assert_eq!(decoded, report);
     }
 }

--- a/docs/atm-quickstart.md
+++ b/docs/atm-quickstart.md
@@ -77,7 +77,7 @@ The smallest production-ready ATM composition is:
 let observability = Observability::builder(
     ObservabilityConfig::default_for(
         ToolName::new("atm")?,
-        std::path::PathBuf::from("/var/log/atm"),
+        std::path::PathBuf::from("/var/log/<service>"),
     ),
 )
 .register_subscriber(agent_info_subscriber_registration)

--- a/docs/public-api-checklist.md
+++ b/docs/public-api-checklist.md
@@ -50,7 +50,7 @@ Note:
 - [x] `Level`
 - [x] `LevelFilter`
 - [x] `ProcessIdentity`
-- [x] `ProcessIdentityPolicy`
+- [x] `ProcessIdentityPolicy` — intentionally no serde; runtime policy only
 - [x] `ProcessIdentityResolver`
 - [x] `TraceId`
 - [x] `SpanId`
@@ -81,8 +81,8 @@ Note:
 - [x] `LogProjector<T>`
 - [x] `SpanProjector<T>`
 - [x] `MetricProjector<T>`
-- [x] `SubscriberRegistration<T>`
-- [x] `ProjectionRegistration<T>`
+- [x] `SubscriberRegistration<T>` — intentionally no serde; construction-time registration only
+- [x] `ProjectionRegistration<T>` — intentionally no serde; construction-time registration only
 - [x] `InitError`
 - [x] `EventError`
 - [x] `FlushError`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -80,7 +80,7 @@ This crate owns shared neutral contracts only.
 - TYP-016 `SpanRecord<SpanEnded>` shall be reachable only through `SpanRecord<SpanStarted>::end(...)`.
 - TYP-017 Producer-facing `SpanRecord<S>` fields shall be private, with read access through accessors.
 - TYP-018 Final span duration shall be exposed only on `SpanRecord<SpanEnded>`.
-- TYP-019 `SpanState` serialization shall be derived from typestate at export/serialization time and shall not be a producer-facing mutable field.
+- TYP-019 `SpanState` serialization shall be derived from typestate at export/serialization time and shall not be a producer-facing mutable field. The `SpanStarted` and `SpanEnded` marker structs are the span-state mechanism; no additional producer-facing state type is required.
 - TYP-020 `Observable` shall remain an open trait for consumer-owned payload types.
 - TYP-021 `ObservationSubscriber<T>`, `ObservationFilter<T>`, `LogProjector<T>`, `SpanProjector<T>`, and `MetricProjector<T>` shall remain open extension points.
 - TYP-022 Crate-local emitter traits that are sealed to their implementing facade types shall be owned by the crate that implements them rather than by `sc-observability-types`.

--- a/examples/atm-adapter-example/src/main.rs
+++ b/examples/atm-adapter-example/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
 
     let _observability_config = ObservabilityConfig {
         tool_name: ToolName::new("atm").expect("tool name"),
-        log_root: std::path::PathBuf::from("/var/log/atm"),
+        log_root: std::path::PathBuf::from("/var/log/<service>"),
         env_prefix: EnvPrefix::new("ATM").expect("env prefix"),
         queue_capacity: 1024,
         rotation: RotationPolicy::default(),


### PR DESCRIPTION
## Sprint

**OBS-PHASE-1-S1** — Sprint 1 / M0+M1: `sc-observability-types`

## Summary

- Workspace baseline: all four crates present, per-crate `constants.rs` and `error_codes.rs` in place
- Validated name newtypes, `ErrorCode`, `Diagnostic`, `Remediation`, `ErrorContext`
- `TraceId`, `SpanId`, `TraceContext`
- `Observation<T>`, `LogEvent`, `SpanRecord<S>`, `SpanSignal`, `MetricRecord`
- `LoggingHealthReport`, `ObservabilityHealthReport`, `TelemetryHealthReport` (SSOT here, re-exported by owning crates)
- `EventError`, `ObservationError`, `TelemetryError` (SSOT here)
- Shared open traits, `constants.rs`, `error_codes.rs`
- Serde coverage for all public data contracts
- Typestate span lifecycle (`SpanRecord<SpanStarted>` / `SpanRecord<SpanEnded>`)
- `CompleteSpan` NOT included (belongs in `sc-observability-otlp`)
- `docs/public-api-checklist.md` `sc-observability-types` section frozen `[x]`

## Acceptance Criteria

- [ ] All public types compile without placeholder fields
- [ ] Unit tests: newtype validation, TraceId/SpanId, ErrorContext rendering, serde round-trips, typestate lifecycle
- [ ] `cargo fmt --check` passes
- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] All CI gates pass
- [ ] API checklist frozen for `sc-observability-types`

## References

- `docs/phase-1-sprint-assignment.md` §3 Sprint 1
- `docs/implementation-plan.md` §3 M0+M1
- `docs/test-strategy.md` §3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)