### PR TITLE
docs: zero-tolerance pre-existing issue policy for QA agents

### DIFF
--- a/.claude/agents/arch-qa.md
+++ b/.claude/agents/arch-qa.md
@@ -53,6 +53,13 @@ Severity: BLOCKING
 ### RULE-006: No hardcoded `/tmp/` paths in production code
 Severity: IMPORTANT
 
+## Zero Tolerance for Pre-Existing Issues
+
+- Do NOT dismiss violations as "pre-existing" or "not worsened."
+- Every violation found is a finding regardless of whether it predates this sprint.
+- List each finding with file:line and a remediation note.
+- The pre-existing/new distinction is informational only. It does not change severity or blocking status.
+
 ## Output Contract
 
 Return fenced JSON only.
@@ -72,7 +79,8 @@ Return fenced JSON only.
       "severity": "BLOCKING|IMPORTANT|MINOR",
       "file": "crates/sc-observability/src/lib.rs",
       "line": 1,
-      "description": "description"
+      "description": "description",
+      "remediation": "specific corrective action"
     }
   ],
   "merge_ready": true,

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -39,20 +39,42 @@ Use standard GitHub CLI:
 - Use Task/background agents for QA execution.
 - Keep all fix routing through team-lead.
 
+### Zero Tolerance for Pre-Existing Issues
+
+- Do NOT dismiss violations as "pre-existing" or "not worsened."
+- Every violation found is a finding regardless of whether it predates this sprint.
+- List each finding with file:line and a remediation note.
+- The pre-existing/new distinction is informational only. It does not change severity or blocking status.
+
 ## QA Execution Contract
 
 ### `rust-qa-agent`
 - static review
 - `cargo clippy --all-targets --all-features -- -D warnings`
 - `cargo test --workspace`
+- Zero-tolerance rule:
+  - Do NOT dismiss violations as "pre-existing" or "not worsened."
+  - Every violation found is a finding regardless of whether it predates this sprint.
+  - List each finding with file:line and a remediation note.
+  - The pre-existing/new distinction is informational only. It does not change severity or blocking status.
 
 ### `req-qa`
 - requirements/design/plan compliance against local docs
+- Zero-tolerance rule:
+  - Do NOT dismiss violations as "pre-existing" or "not worsened."
+  - Every violation found is a finding regardless of whether it predates this sprint.
+  - List each finding with file:line and a remediation note.
+  - The pre-existing/new distinction is informational only. It does not change severity or blocking status.
 
 ### `arch-qa`
 - dependency direction
 - crate layering
 - structural fitness
+- Zero-tolerance rule:
+  - Do NOT dismiss violations as "pre-existing" or "not worsened."
+  - Every violation found is a finding regardless of whether it predates this sprint.
+  - List each finding with file:line and a remediation note.
+  - The pre-existing/new distinction is informational only. It does not change severity or blocking status.
 
 ## Reporting Format
 

--- a/.claude/agents/req-qa.md
+++ b/.claude/agents/req-qa.md
@@ -47,6 +47,13 @@ Input must be fenced JSON:
    `docs/project-plan.md`.
 4. Detect cross-document drift or contradictions.
 
+## Zero Tolerance for Pre-Existing Issues
+
+- Do NOT dismiss violations as "pre-existing" or "not worsened."
+- Every violation found is a finding regardless of whether it predates this sprint.
+- List each finding with source/target file:line and a remediation note.
+- The pre-existing/new distinction is informational only. It does not change severity or blocking status.
+
 ## Output Contract
 
 Return fenced JSON only.

--- a/.claude/agents/rust-code-reviewer.md
+++ b/.claude/agents/rust-code-reviewer.md
@@ -26,13 +26,20 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 
 Rate each potential issue on a scale from 0-100:
 
-- **0**: Not confident at all. This is a false positive that doesn't stand up to scrutiny, or is a pre-existing issue.
+- **0**: Not confident at all. This is a false positive that doesn't stand up to scrutiny.
 - **25**: Somewhat confident. This might be a real issue, but may also be a false positive. If stylistic, it wasn't explicitly called out in project guidelines.
 - **50**: Moderately confident. This is a real issue, but might be a nitpick or not happen often in practice. Not very important relative to the rest of the changes.
 - **75**: Highly confident. Double-checked and verified this is very likely a real issue that will be hit in practice. The existing approach is insufficient. Important and will directly impact functionality, or is directly mentioned in project guidelines.
 - **100**: Absolutely certain. Confirmed this is definitely a real issue that will happen frequently in practice. The evidence directly confirms this.
 
 **Only report issues with confidence ≥ 80.** Focus on issues that truly matter - quality over quantity.
+
+## Zero Tolerance for Pre-Existing Issues
+
+- Do NOT dismiss violations as "pre-existing" or "not worsened."
+- Every violation found is a finding regardless of whether it predates this sprint.
+- Every reported finding must include file:line and a remediation note.
+- The pre-existing/new distinction is informational only. It does not change severity or blocking status.
 
 ## Output Guidance
 

--- a/.claude/agents/rust-qa-agent.md
+++ b/.claude/agents/rust-qa-agent.md
@@ -78,6 +78,13 @@ Monitor test execution time:
 - **Report all findings** - No silent failures
 - **Test quality matters** - Meaningful tests that catch real bugs > hitting coverage numbers
 
+## Zero Tolerance for Pre-Existing Issues
+
+- Do NOT dismiss violations as "pre-existing" or "not worsened."
+- Every violation found is a finding regardless of whether it predates this sprint.
+- List each finding with file:line and a remediation note.
+- The pre-existing/new distinction is informational only. It does not change severity or blocking status.
+
 ## Output Guidance
 
 Return fenced JSON only. Do not return markdown summaries.


### PR DESCRIPTION
## Summary
- Adds zero-tolerance pre-existing issue policy to `quality-mgr.md`, `rust-qa-agent.md`, `req-qa.md`, `arch-qa.md`, and `rust-code-reviewer.md`
- Removes `or is a pre-existing issue` exemption from confidence score 0 definition in `rust-code-reviewer.md`

## Test plan
- [ ] Policy block present in all targeted agent files under `## CRITICAL CONSTRAINTS` or equivalent
- [ ] No remaining pre-existing issue exemption in confidence score definitions
- [ ] Review by arch-obs before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)