### PR TITLE
docs: README.md and PUBLISHING.md for 1.0.0 release

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,87 @@
+# Publishing Guide
+
+This repo uses a single source of truth for release artifacts:
+
+- Manifest: `release/publish-artifacts.toml`
+- Loader/validator: `scripts/release_artifacts.py`
+
+Do not hardcode crate lists or publish order in docs or workflows. Update the
+manifest instead.
+
+## Distribution Channels
+
+- **crates.io**: all four crates in the workspace
+  - [`sc-observability-types`](https://crates.io/crates/sc-observability-types)
+  - [`sc-observability`](https://crates.io/crates/sc-observability)
+  - [`sc-observe`](https://crates.io/crates/sc-observe)
+  - [`sc-observability-otlp`](https://crates.io/crates/sc-observability-otlp)
+- **GitHub Releases**: <https://github.com/randlee/sc-observability/releases>
+
+## Workflows
+
+- Preflight: `.github/workflows/release-preflight.yml`
+- Release: `.github/workflows/release.yml`
+
+Both workflows are manual dispatch (`workflow_dispatch`).
+
+## Standard Flow
+
+1. Ensure `develop` contains the release version bump and all work is merged.
+2. Run the preflight workflow from `develop` (or `main` post-merge):
+   - `version=<X.Y.Z or vX.Y.Z>`
+   - `run_by_agent=publisher`
+3. Preflight validates formatting, clippy, tests, manifest completeness, publish
+   order, repo boundaries, and version consistency. It runs `cargo publish
+   --dry-run` for each crate in manifest order.
+4. Merge `develop` to `main` once CI and preflight are green.
+5. Run the release workflow with `version=<X.Y.Z or vX.Y.Z>`.
+6. Release workflow tags, publishes crates in manifest order (with propagation
+   waits between crates), and creates the GitHub release.
+
+## Initial Publish Note
+
+For the first publish (all four crates absent from crates.io), preflight
+automatically detects initial-release mode and uses `--no-verify` on the
+dry-run to skip path dependency resolution. This is safe because correctness
+is already validated by the preceding fmt/clippy/test steps.
+
+## Publish Order
+
+Crates must be published in dependency order (defined in the manifest):
+
+| Order | Crate | Wait after publish |
+|-------|-------|--------------------|
+| 1 | `sc-observability-types` | 30s |
+| 2 | `sc-observability` | 30s |
+| 3 | `sc-observe` | 30s |
+| 4 | `sc-observability-otlp` | — |
+
+## Local Validation Commands
+
+```bash
+# Show publish plan
+python3 scripts/release_artifacts.py list-publish-plan \
+  --manifest release/publish-artifacts.toml
+
+# Validate manifest completeness against workspace
+python3 scripts/release_artifacts.py validate-manifest \
+  --manifest release/publish-artifacts.toml \
+  --workspace-toml Cargo.toml
+
+# Verify version matches workspace
+python3 scripts/release_artifacts.py verify-version \
+  --manifest release/publish-artifacts.toml \
+  --workspace-toml Cargo.toml \
+  --version 1.0.0
+```
+
+## Updating Release Artifacts
+
+When adding or reordering crates:
+
+1. Update `release/publish-artifacts.toml`.
+2. Run `validate-manifest` locally to confirm consistency.
+3. Run CI/Preflight to validate end-to-end.
+
+No workflow edits are required for normal artifact-list changes when the
+manifest is kept current.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,60 @@
 # sc-observability
 
-Standalone workspace for:
-- `sc-observability-types`
-- `sc-observability`
-- `sc-observability-otlp`
+Structured logging and OpenTelemetry observability infrastructure crates for use across projects.
 
-This repo is intended to replace the in-workspace `sc-observability*` crates
-currently published from `agent-team-mail`.
+## Crates
+
+| Crate | Description |
+|-------|-------------|
+| [`sc-observability-types`](crates/sc-observability-types/) | Shared log type contracts — payload types, severity levels, structured field definitions |
+| [`sc-observability`](crates/sc-observability/) | Core structured logging backend — `AppLogger` initialization, sink routing, and session lifecycle |
+| [`sc-observe`](crates/sc-observe/) | Lightweight observer façade — emit structured log events without owning the logger lifecycle |
+| [`sc-observability-otlp`](crates/sc-observability-otlp/) | OpenTelemetry export adapter — bridges `sc-observability` events to OTLP collectors |
+
+## Usage
+
+Add the crates you need to your `Cargo.toml`:
+
+```toml
+# For applications that own the logger lifecycle
+sc-observability = "1"
+sc-observability-types = "1"
+
+# For libraries that emit log events but don't own the logger
+sc-observe = "1"
+
+# Optional: export to an OpenTelemetry collector
+sc-observability-otlp = "1"
+```
+
+### Quick start
+
+```rust
+use sc_observability::{AppLogger, LoggerConfig};
+use sc_observability_types::Severity;
+
+fn main() {
+    let logger = AppLogger::init(LoggerConfig::default()).expect("logger init failed");
+
+    logger.emit(sc_observe::event!(
+        severity: Severity::Info,
+        message: "application started",
+        fields: { "version" => env!("CARGO_PKG_VERSION") },
+    ));
+
+    // logger shuts down cleanly on drop
+}
+```
+
+See [`examples/`](examples/) for complete usage patterns including OTLP export and adapter integration.
+
+## Design
+
+- **`sc-observability-types`** is the only shared contract crate — consumers and producers depend on it, never on each other.
+- **`sc-observability`** owns logger initialization and sink configuration; only the application binary or top-level integration crate should initialize it.
+- **`sc-observe`** provides a zero-lifecycle façade for library crates that need to emit events without coupling to the backend.
+- **`sc-observability-otlp`** is an optional adapter; include it only when exporting to an OTLP-compatible collector.
+
+## Publishing
+
+See [PUBLISHING.md](PUBLISHING.md) for release and publish procedures.


### PR DESCRIPTION
## Summary

- Rewrites `README.md` with a brief description of all four crates, usage examples, and design rationale — written as production-ready
- Adds `PUBLISHING.md` documenting all distribution channels (crates.io × 4, GitHub Releases), standard release flow, initial-release mode, publish order table, and local validation commands

## Test plan

- [ ] Review README crate descriptions and quick-start example
- [ ] Review PUBLISHING flow and verify publish order table matches `release/publish-artifacts.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)