### PR TITLE
fix: runtime correctness + platform parity (PRR PR-1)

### DIFF
--- a/crates/sc-observability-otlp/src/lib.rs
+++ b/crates/sc-observability-otlp/src/lib.rs
@@ -429,6 +429,7 @@ impl SpanAssembler {
                     record.trace().trace_id.as_str(),
                     record.trace().span_id.as_str(),
                 );
+                self.events.insert(key.clone(), Vec::new());
                 self.started.insert(key, record);
                 Ok(None)
             }
@@ -460,10 +461,16 @@ impl SpanAssembler {
                         ),
                     ))));
                 }
-                Ok(Some(CompleteSpan {
-                    record,
-                    events: self.events.remove(&key).unwrap_or_default(),
-                }))
+                let Some(events) = self.events.remove(&key) else {
+                    return Err(EventError(Box::new(ErrorContext::new(
+                        error_codes::TELEMETRY_SPAN_ASSEMBLY_FAILED,
+                        "missing span event buffer for a started span",
+                        Remediation::not_recoverable(
+                            "restart telemetry to restore span assembly state",
+                        ),
+                    ))));
+                };
+                Ok(Some(CompleteSpan { record, events }))
             }
         }
     }
@@ -496,6 +503,11 @@ pub struct Telemetry {
     runtime: Mutex<TelemetryRuntime>,
     dropped_exports_total: AtomicU64,
     malformed_spans_total: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FlushOutcome {
+    had_export_failure: bool,
 }
 
 #[derive(Default)]
@@ -660,6 +672,11 @@ impl Telemetry {
 
     /// Flushes buffered logs, spans, and metrics through the configured exporters.
     pub fn flush(&self) -> Result<(), FlushError> {
+        let _ = self.flush_outcome()?;
+        Ok(())
+    }
+
+    fn flush_outcome(&self) -> Result<FlushOutcome, FlushError> {
         let (log_batch, span_batch, metric_batch) = {
             let mut runtime = self.runtime.lock().expect("telemetry runtime poisoned");
             let log_batch = if self.config.logs.is_some() {
@@ -679,11 +696,13 @@ impl Telemetry {
             };
             (log_batch, span_batch, metric_batch)
         };
+        let mut had_export_failure = false;
 
         if !log_batch.is_empty() {
             match self.log_exporter.export_logs(&log_batch) {
                 Ok(()) => self.record_export_success(ExporterKind::Logs),
                 Err(err) => {
+                    had_export_failure = true;
                     self.record_export_failure(ExporterKind::Logs, log_batch.len() as u64, err)
                 }
             }
@@ -693,6 +712,7 @@ impl Telemetry {
             match self.trace_exporter.export_spans(&span_batch) {
                 Ok(()) => self.record_export_success(ExporterKind::Traces),
                 Err(err) => {
+                    had_export_failure = true;
                     self.record_export_failure(ExporterKind::Traces, span_batch.len() as u64, err)
                 }
             }
@@ -701,15 +721,18 @@ impl Telemetry {
         if !metric_batch.is_empty() {
             match self.metric_exporter.export_metrics(&metric_batch) {
                 Ok(()) => self.record_export_success(ExporterKind::Metrics),
-                Err(err) => self.record_export_failure(
-                    ExporterKind::Metrics,
-                    metric_batch.len() as u64,
-                    err,
-                ),
+                Err(err) => {
+                    had_export_failure = true;
+                    self.record_export_failure(
+                        ExporterKind::Metrics,
+                        metric_batch.len() as u64,
+                        err,
+                    )
+                }
             }
         }
 
-        Ok(())
+        Ok(FlushOutcome { had_export_failure })
     }
 
     /// Flushes buffers, drops incomplete spans, and transitions the runtime to shutdown.
@@ -718,9 +741,7 @@ impl Telemetry {
             return Ok(());
         }
 
-        // Best-effort flush on shutdown: exporter failures are recorded in health,
-        // but shutdown itself stays fail-open so callers can continue teardown.
-        let _ = self.flush();
+        let flush_outcome = self.flush_outcome().map_err(shutdown_flush_error)?;
         let dropped = self
             .runtime
             .lock()
@@ -744,6 +765,16 @@ impl Telemetry {
             runtime.trace_status.state = ExporterHealthState::Degraded;
             runtime.trace_status.last_error = Some(summary.clone());
             runtime.last_error = Some(summary);
+        }
+
+        if flush_outcome.had_export_failure {
+            return Err(shutdown_export_failure(
+                self.runtime
+                    .lock()
+                    .expect("telemetry runtime poisoned")
+                    .last_error
+                    .clone(),
+            ));
         }
 
         Ok(())
@@ -973,6 +1004,41 @@ fn error_context_from_diagnostic(diagnostic: &sc_observability_types::Diagnostic
     context
 }
 
+fn shutdown_flush_error(error: FlushError) -> ShutdownError {
+    ShutdownError(Box::new(
+        ErrorContext::new(
+            error_codes::TELEMETRY_FLUSH_FAILED,
+            "failed to flush telemetry during shutdown",
+            Remediation::recoverable(
+                "inspect telemetry health and retry shutdown after the exporter recovers",
+                ["retry shutdown"],
+            ),
+        )
+        .source(Box::new(error)),
+    ))
+}
+
+fn shutdown_export_failure(summary: Option<DiagnosticSummary>) -> ShutdownError {
+    let mut context = ErrorContext::new(
+        error_codes::TELEMETRY_FLUSH_FAILED,
+        "failed to flush telemetry during shutdown",
+        Remediation::recoverable(
+            "inspect telemetry health and retry shutdown after the exporter recovers",
+            ["retry shutdown"],
+        ),
+    );
+    if let Some(summary) = summary {
+        context = context.cause(summary.message);
+        if let Some(code) = summary.code {
+            context = context.detail(
+                "exporter_error_code",
+                Value::String(code.as_str().to_owned()),
+            );
+        }
+    }
+    ShutdownError(Box::new(context))
+}
+
 fn span_key(trace_id: &str, span_id: &str) -> String {
     format!("{trace_id}:{span_id}")
 }
@@ -1191,6 +1257,39 @@ mod tests {
     }
 
     #[test]
+    fn span_assembler_reports_missing_event_buffer_explicitly() {
+        let trace = trace_context();
+        let started = SpanRecord::<SpanStarted>::new(
+            Timestamp::UNIX_EPOCH,
+            service_name(),
+            ActionName::new("agent.run").expect("valid action"),
+            trace.clone(),
+            Map::new(),
+        );
+        let ended = started
+            .clone()
+            .end(sc_observability_types::SpanStatus::Ok, DurationMs::from(42));
+        let mut assembler = SpanAssembler::new();
+
+        assert!(
+            assembler
+                .push(SpanSignal::Started(started))
+                .expect("started")
+                .is_none()
+        );
+        let key = span_key(trace.trace_id.as_str(), trace.span_id.as_str());
+        assembler.events.remove(&key);
+
+        let error = assembler
+            .push(SpanSignal::Ended(ended))
+            .expect_err("missing event buffer should be explicit");
+        assert_eq!(
+            error.diagnostic().message,
+            "missing span event buffer for a started span"
+        );
+    }
+
+    #[test]
     fn incomplete_span_drop_accounting_is_tracked() {
         let trace = trace_context();
         let started = SpanRecord::<SpanStarted>::new(
@@ -1399,7 +1498,7 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_absorbs_export_failures_and_records_them_in_health() {
+    fn shutdown_propagates_flush_failures_and_records_them_in_health() {
         let log_exporter = Arc::new(RecordingLogExporter::default());
         log_exporter.fail.store(true, Ordering::SeqCst);
         let telemetry = Telemetry::new_with_exporters(
@@ -1414,7 +1513,13 @@ mod tests {
             .emit_log(&log_event(service_name(), "shutdown-export"))
             .expect("emit");
 
-        telemetry.shutdown().expect("shutdown remains fail-open");
+        let error = telemetry
+            .shutdown()
+            .expect_err("shutdown should surface flush failures");
+        assert_eq!(
+            error.diagnostic().message,
+            "failed to flush telemetry during shutdown"
+        );
 
         let health = telemetry.health();
         assert_eq!(health.state, TelemetryHealthState::Unavailable);

--- a/crates/sc-observability/src/follow.rs
+++ b/crates/sc-observability/src/follow.rs
@@ -52,8 +52,20 @@ impl LogFollowSession {
             &self.query,
             &mut self.tracked_files,
         );
-        self.health.record_result(&result);
-        result
+        match result {
+            Ok(outcome) => {
+                if let Some(summary) = outcome.reset_summary {
+                    self.health.record_nonfatal_summary(summary);
+                } else {
+                    self.health.mark_healthy();
+                }
+                Ok(outcome.snapshot)
+            }
+            Err(error) => {
+                self.health.record_error(&error);
+                Err(error)
+            }
+        }
     }
 
     /// Returns the current query/follow health snapshot for this session.

--- a/crates/sc-observability/src/health.rs
+++ b/crates/sc-observability/src/health.rs
@@ -52,6 +52,12 @@ impl QueryHealthTracker {
         }
     }
 
+    pub(crate) fn record_nonfatal_summary(&self, summary: DiagnosticSummary) {
+        let mut report = self.report.lock().expect("query health poisoned");
+        report.state = QueryHealthState::Degraded;
+        report.last_error = Some(summary);
+    }
+
     pub(crate) fn record_result<T>(&self, result: &Result<T, QueryError>) {
         match result {
             Ok(_) => self.mark_healthy(),

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -1587,6 +1587,15 @@ mod tests {
             after_truncate == vec!["after-truncate"]
                 || after_truncate == vec!["backlog", "before-truncate", "after-truncate"]
         );
+        let truncate_health = follow.health();
+        assert_eq!(truncate_health.state, QueryHealthState::Degraded);
+        assert!(
+            truncate_health
+                .last_error
+                .expect("truncate health summary")
+                .message
+                .contains("truncation")
+        );
 
         fs::remove_file(&active_path).expect("remove active log");
         logger
@@ -1594,5 +1603,14 @@ mod tests {
             .expect("emit after recreate");
         let after_recreate = drain_follow_until_request_id(&mut follow, "after-recreate");
         assert_eq!(after_recreate, vec!["after-recreate"]);
+        let recreate_health = follow.health();
+        assert_eq!(recreate_health.state, QueryHealthState::Degraded);
+        assert!(
+            recreate_health
+                .last_error
+                .expect("recreate health summary")
+                .message
+                .contains("identity changed")
+        );
     }
 }

--- a/crates/sc-observability/src/query.rs
+++ b/crates/sc-observability/src/query.rs
@@ -3,7 +3,8 @@ use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use sc_observability_types::{
-    ErrorContext, LogEvent, LogOrder, LogQuery, LogSnapshot, QueryError, Remediation, error_codes,
+    DiagnosticSummary, ErrorContext, LogEvent, LogOrder, LogQuery, LogSnapshot, QueryError,
+    Remediation, Timestamp, error_codes,
 };
 use serde_json::{Value, json};
 
@@ -36,6 +37,26 @@ pub(crate) struct TrackedFile {
     pub(crate) offset: u64,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct FollowPollOutcome {
+    pub(crate) snapshot: LogSnapshot,
+    pub(crate) reset_summary: Option<DiagnosticSummary>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FollowOffsetResetReason {
+    NewActiveFile,
+    Recreated,
+    Truncated,
+    MissingState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrackedOffsetDecision {
+    offset: u64,
+    reset_reason: Option<FollowOffsetResetReason>,
+}
+
 pub(crate) fn query_snapshot(
     active_log_path: &Path,
     query: &LogQuery,
@@ -62,44 +83,130 @@ pub(crate) fn poll_follow_snapshot(
     active_log_path: &Path,
     query: &LogQuery,
     tracked_files: &mut Vec<TrackedFile>,
-) -> Result<LogSnapshot, QueryError> {
+) -> Result<FollowPollOutcome, QueryError> {
     let resolved = resolve_visible_files(active_log_path)?;
     let previous = std::mem::take(tracked_files);
+    let mut reset_summary = None;
     *tracked_files = resolved
         .iter()
-        .map(|file| TrackedFile {
-            path: file.path.clone(),
-            identity: file.identity.clone(),
-            offset: tracked_offset_for(file, &previous),
+        .map(|file| {
+            let expected_active_rotation = file.path == active_log_path
+                && previous
+                    .iter()
+                    .find(|tracked| tracked.path == file.path)
+                    .is_some_and(|tracked| {
+                        tracked.identity != file.identity
+                            && resolved.iter().any(|other| {
+                                other.path != file.path && other.identity == tracked.identity
+                            })
+                    });
+            let decision = tracked_offset_for(
+                file,
+                &previous,
+                file.path == active_log_path,
+                expected_active_rotation,
+            );
+            if reset_summary.is_none() {
+                reset_summary = decision
+                    .reset_reason
+                    .and_then(|reason| follow_reset_summary(&file.path, reason));
+            }
+
+            TrackedFile {
+                path: file.path.clone(),
+                identity: file.identity.clone(),
+                offset: decision.offset,
+            }
         })
         .collect();
 
-    read_incremental_snapshot(query, &resolved, tracked_files)
+    Ok(FollowPollOutcome {
+        snapshot: read_incremental_snapshot(query, &resolved, tracked_files)?,
+        reset_summary,
+    })
 }
 
-fn tracked_offset_for(file: &ResolvedLogFile, previous: &[TrackedFile]) -> u64 {
+fn tracked_offset_for(
+    file: &ResolvedLogFile,
+    previous: &[TrackedFile],
+    is_active_file: bool,
+    expected_active_rotation: bool,
+) -> TrackedOffsetDecision {
     if let Some(tracked) = previous.iter().find(|tracked| tracked.path == file.path) {
         if tracked.identity != file.identity {
-            return 0;
+            return TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(if expected_active_rotation {
+                    FollowOffsetResetReason::NewActiveFile
+                } else {
+                    FollowOffsetResetReason::Recreated
+                }),
+            };
         }
         return if tracked.offset <= file.len {
-            tracked.offset
+            TrackedOffsetDecision {
+                offset: tracked.offset,
+                reset_reason: None,
+            }
         } else {
-            0
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::Truncated),
+            }
         };
     }
 
-    previous
+    if let Some(tracked) = previous
         .iter()
         .find(|tracked| tracked.identity == file.identity)
-        .map(|tracked| {
-            if tracked.offset <= file.len {
-                tracked.offset
-            } else {
-                0
+    {
+        return if tracked.offset <= file.len {
+            TrackedOffsetDecision {
+                offset: tracked.offset,
+                reset_reason: None,
             }
-        })
-        .unwrap_or(0)
+        } else {
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::Truncated),
+            }
+        };
+    }
+
+    TrackedOffsetDecision {
+        offset: 0,
+        reset_reason: (!previous.is_empty()).then_some(if is_active_file {
+            FollowOffsetResetReason::NewActiveFile
+        } else {
+            FollowOffsetResetReason::MissingState
+        }),
+    }
+}
+
+fn follow_reset_summary(path: &Path, reason: FollowOffsetResetReason) -> Option<DiagnosticSummary> {
+    let message = match reason {
+        FollowOffsetResetReason::NewActiveFile | FollowOffsetResetReason::MissingState => {
+            return None;
+        }
+        FollowOffsetResetReason::Recreated => {
+            format!(
+                "follow offset reset after log identity changed at {}",
+                path.display()
+            )
+        }
+        FollowOffsetResetReason::Truncated => {
+            format!(
+                "follow offset reset after log truncation at {}",
+                path.display()
+            )
+        }
+    };
+
+    Some(DiagnosticSummary {
+        code: None,
+        message,
+        at: Timestamp::now_utc(),
+    })
 }
 
 pub(crate) fn shutdown_error() -> QueryError {
@@ -410,7 +517,13 @@ mod tests {
             len: 512,
         };
 
-        assert_eq!(tracked_offset_for(&recreated, &previous), 0);
+        assert_eq!(
+            tracked_offset_for(&recreated, &previous, true, false),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::Recreated),
+            }
+        );
     }
 
     #[test]
@@ -426,7 +539,13 @@ mod tests {
             len: 512,
         };
 
-        assert_eq!(tracked_offset_for(&rotated, &previous), 256);
+        assert_eq!(
+            tracked_offset_for(&rotated, &previous, false, false),
+            TrackedOffsetDecision {
+                offset: 256,
+                reset_reason: None,
+            }
+        );
     }
 
     #[cfg(windows)]
@@ -449,6 +568,100 @@ mod tests {
             len: 64,
         };
 
-        assert_eq!(tracked_offset_for(&recreated, &previous), 0);
+        assert_eq!(
+            tracked_offset_for(&recreated, &previous, true, false),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::Recreated),
+            }
+        );
+    }
+
+    #[test]
+    fn follow_tracking_marks_truncation_when_offset_exceeds_current_len() {
+        let previous = vec![TrackedFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(1),
+            offset: 256,
+        }];
+        let truncated = ResolvedLogFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(1),
+            len: 32,
+        };
+
+        assert_eq!(
+            tracked_offset_for(&truncated, &previous, true, false),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::Truncated),
+            }
+        );
+    }
+
+    #[test]
+    fn follow_tracking_treats_new_active_file_as_expected_rotation() {
+        let previous = vec![TrackedFile {
+            path: PathBuf::from("rotated.log.jsonl.1"),
+            identity: test_identity(7),
+            offset: 256,
+        }];
+        let new_file = ResolvedLogFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(9),
+            len: 64,
+        };
+
+        assert_eq!(
+            tracked_offset_for(&new_file, &previous, true, false),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::NewActiveFile),
+            }
+        );
+    }
+
+    #[test]
+    fn follow_tracking_marks_missing_state_when_untracked_non_active_file_appears() {
+        let previous = vec![TrackedFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(7),
+            offset: 256,
+        }];
+        let new_file = ResolvedLogFile {
+            path: PathBuf::from("active.log.jsonl.2"),
+            identity: test_identity(9),
+            len: 64,
+        };
+
+        assert_eq!(
+            tracked_offset_for(&new_file, &previous, false, false),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::MissingState),
+            }
+        );
+    }
+
+    #[test]
+    fn follow_tracking_treats_active_path_identity_change_as_expected_rotation() {
+        let previous = vec![TrackedFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(7),
+            offset: 256,
+        }];
+        let new_active = ResolvedLogFile {
+            path: PathBuf::from("active.log.jsonl"),
+            identity: test_identity(9),
+            len: 64,
+        };
+
+        assert_eq!(
+            tracked_offset_for(&new_active, &previous, true, true),
+            TrackedOffsetDecision {
+                offset: 0,
+                reset_reason: Some(FollowOffsetResetReason::NewActiveFile),
+            }
+        );
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,7 +389,11 @@ Follow strategy:
 - `poll()` reads appended records since the last successful poll
 - if the active file shrinks or its file identity changes, the session treats
   that as rotation/truncation, reopens the new active file, and resumes from
-  offset `0`
+  offset `0` on Unix-family platforms
+- Windows uses a best-effort `(len, modified_nanos)` fallback because stable
+  Rust does not expose a standard-library file identity equivalent to Unix
+  `(dev, ino)`, so truncate/recreate detection there is explicitly
+  non-promissory for v1
 - the follow path remains poll-based and caller-driven; no async watch service
   is introduced
 

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -8,6 +8,20 @@
 3. Do not derive paths from ATM-specific home helpers or runtime roots.
 4. Use `PathBuf` and `.join()` for path construction.
 5. Any OS-specific transport or file behavior must be behind explicit cfg gates.
+6. If stable Rust lacks the platform API needed to preserve parity, the shared
+   docs must state the degraded guarantee explicitly instead of implying
+   cross-platform equivalence.
+
+## Current Platform Limitations
+
+1. Query/follow file identity is strong on Unix-family platforms through
+   `(dev, ino)` metadata.
+2. Windows currently falls back to `(len, modified_nanos)` because stable Rust
+   does not expose a reliable replacement for Unix file identity in the
+   standard library.
+3. As a result, Windows truncate/recreate detection for `Logger::follow()` and
+   `JsonlLogReader::follow()` is best-effort only in v1 and must not be
+   documented as a parity guarantee with Unix/macOS behavior.
 
 ## Test Rules
 

--- a/docs/pre-publish-recovery-plan.md
+++ b/docs/pre-publish-recovery-plan.md
@@ -218,8 +218,11 @@ Implement the missing historical query and synchronous tail APIs in
 - historical reads cover the active log plus the rotation set that matches the
   documented naming layout
 - `LogOrder::OldestFirst` and `LogOrder::NewestFirst` are deterministic
-- follow sessions survive active-file rename/recreate during rotation
+- follow sessions survive active-file rename/recreate during rotation on
+  Unix-family platforms
 - committed records are neither duplicated nor silently skipped across rotation
+  on Unix-family platforms; Windows remains best-effort because stable Rust
+  does not expose a reliable file identity equivalent to `(dev, ino)`
 - `follow().poll()` is synchronous and caller-driven
 - `query()` and `follow()` remain available without `sc-observe` or OTLP
 
@@ -240,7 +243,9 @@ Implement the missing historical query and synchronous tail APIs in
 - invalid query validation paths
 - malformed record decode failure path
 - follow session starts at tail, not backlog
-- follow session after rotation/recreate
+- follow session after rotation/recreate on Unix-family platforms
+- explicit Windows limitation coverage for best-effort truncate/recreate
+  detection
 - logger shutdown makes query/follow unavailable where appropriate
 - offline `JsonlLogReader` parity tests against `Logger`
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -149,7 +149,7 @@ This crate is the lightweight logging layer.
 - LOG-027 `LogFollowSession` shall expose synchronous polling and shall not require an async runtime, background task, or file watcher to deliver new records.
 - LOG-028 `sc-observability` shall provide `JsonlLogReader` as an independent JSONL file reader for historical query and follow operations without requiring a live `Logger`, `sc-observe`, or `sc-observability-otlp`.
 - LOG-029 Historical query and follow behavior shall operate over the active JSONL log and its rotation set using the documented `sc-observability` naming/layout rules.
-- LOG-030 Rotation handling for query/follow shall avoid duplicating or silently skipping committed log records when the active file is renamed or recreated.
+- LOG-030 Rotation handling for query/follow shall avoid duplicating or silently skipping committed log records when the active file is renamed or recreated on Unix-family platforms. On Windows, stable Rust does not expose a reliable file identity equivalent to `(dev, ino)`, so truncate/recreate detection remains best-effort and is not a release guarantee for v1.
 - LOG-031 `LoggingHealthReport` shall expose query/follow availability through an optional `QueryHealthReport`.
 - LOG-032 Query/follow APIs shall remain usable in logging-only deployments and shall not introduce ATM-specific types, daemon requirements, or `agent-team-mail-*` dependencies.
 - LOG-033 `JsonlLogReader` query/follow operations shall remain independent of `Logger` lifecycle and shall stay usable for offline inspection after a logger-owned runtime shuts down.
@@ -238,6 +238,7 @@ This crate is the OTel/OTLP layer built on top of `sc-observe`.
 - OTLP-021 `Telemetry` lifecycle behavior shall be explicit:
   - emit methods after `shutdown()` return `TelemetryError::Shutdown`
   - `flush()` attempts to export ready batches and drops incomplete spans only at shutdown/final flush
+  - the first `shutdown()` surfaces any final flush failure as `ShutdownError`
   - repeated `shutdown()` calls are idempotent and return `Ok(())`
 - OTLP-022 `sc-observability-otlp` shall own crate-local sealed signal-emitter traits for direct telemetry injection where needed.
 


### PR DESCRIPTION
## Summary

- **PRR-B-001**: `Telemetry::shutdown()` no longer silently discards `flush()` result
- **PRR-B-007**: Windows follow identity fallback — contract downgraded or stronger identity implemented
- **PRR-I-004**: `SpanAssembler` missing-event case made explicit (no silent `unwrap_or_default`)
- **PRR-I-005**: `tracked_offset_for()` distinguishes truncate/recreate/missing-state with explicit reason

## Part of PRR fix sequence

Sprint order: PR-0 ✅ → **PR-1** → PR-2 → PR-3 → PR-4 → re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)