### PR TITLE
docs: update primary checkout rule to develop with worktrees policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## Critical Workflow Rule
 
-Do not switch the main checkout away from `main` for sprint work.
+Do not switch the primary checkout away from `develop` for sprint work.
 
-- Keep the primary repo checkout on `main`
-- Use git worktrees for feature work when parallel branches are needed
-- Prefer short-lived feature branches targeting `main`
+- Keep the primary repo checkout on `develop`
+- Use git worktrees for all feature/sprint branches
+- All branches other than `develop` must live in worktrees
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary
- Updates `CLAUDE.md` Critical Workflow Rule to codify that the primary checkout stays on `develop`
- All feature/sprint branches must live in git worktrees
- Removes outdated `main`-based checkout guidance

## Test plan
- [ ] Confirm CLAUDE.md diff is accurate
- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)