### PR TITLE
feat: sc-observability skills package and ARCH-001 lib.rs refactor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "sc-observability",
   "owner": {
     "name": "randlee",
-    "email": "randlee@example.com"
+    "email": "randlee@randlee.com"
   },
   "metadata": {
     "description": "Marketplace package for downstream sc-observability setup and review skills.",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "sc-observability",
+  "owner": {
+    "name": "randlee",
+    "email": "randlee@example.com"
+  },
+  "metadata": {
+    "description": "Marketplace package for downstream sc-observability setup and review skills.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "sc-observability",
+      "source": "./packages/sc-observability",
+      "description": "Skills for bootstrapping, adopting, and reviewing sc-observability usage.",
+      "version": "1.0.0",
+      "author": {
+        "name": "randlee"
+      },
+      "license": "MIT",
+      "keywords": [
+        "rust",
+        "observability",
+        "logging",
+        "claude-code",
+        "skills"
+      ],
+      "category": "tools"
+    }
+  ]
+}

--- a/.claude/skills/sc-observability-adopting/SKILL.md
+++ b/.claude/skills/sc-observability-adopting/SKILL.md
@@ -48,3 +48,14 @@ wrapper around the repo's ATM-scoped migration docs.
 - `references/console-and-log-root.md`
 - `references/adoption-checklist.md`
 - migration references as needed
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: migration-specific playbooks stay in `references/`
+  instead of expanding the core skill body

--- a/.claude/skills/sc-observability-adopting/SKILL.md
+++ b/.claude/skills/sc-observability-adopting/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sc-observability-adopting
+description: Use when the user says things like "bring sc-observability into an existing Rust project" or "adopt sc-observability in a codebase that already has logging". Adopts sc-observability incrementally with a logging-first path and focused migration references for log, tracing, or custom JSONL setups.
+---
+
+# SC-Observability Adopting
+
+Use this skill when an existing Rust codebase wants to adopt
+`sc-observability`.
+
+## Workflow
+
+1. Inspect the current logging shape first.
+2. Default to a logging-only adoption path before adding routing or OTLP.
+3. Apply the same house style from
+   `references/standard-configuration.md`.
+4. Use `references/adoption-checklist.md` for the step-by-step insertion
+   plan.
+5. Only load migration references when the project already depends on:
+   - `log`
+   - `tracing`
+   - custom JSONL or custom retained logging
+
+## Scope Boundary
+
+This skill is for adopting `sc-observability` into an existing repo.
+
+Library-specific migration detail lives in:
+
+- `references/migrate-from-log.md`
+- `references/migrate-from-tracing.md`
+- `references/migrate-from-custom-jsonl.md`
+
+These files are new writes for this package. Do not treat this skill as a
+wrapper around the repo's ATM-scoped migration docs.
+
+## Required Guidance
+
+- `~/.<app>` remains a house style, not a crate default.
+- Add `sc-observability-types` directly only for custom sinks or shared-type
+  extension work.
+- Preserve stable `target` and `action` naming while replacing existing
+  logging entry points.
+
+## References
+
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+- `references/adoption-checklist.md`
+- migration references as needed

--- a/.claude/skills/sc-observability-adopting/SKILL.md
+++ b/.claude/skills/sc-observability-adopting/SKILL.md
@@ -56,6 +56,6 @@ Reviewed against
 
 - `SKILL.md` stays concise: confirmed
 - detailed material lives in `references/`: confirmed
-- starter code lives in `assets/`: confirmed
+- no template assets required for this skill: confirmed
 - scope reductions made: migration-specific playbooks stay in `references/`
   instead of expanding the core skill body

--- a/.claude/skills/sc-observability-adopting/references/adoption-checklist.md
+++ b/.claude/skills/sc-observability-adopting/references/adoption-checklist.md
@@ -1,0 +1,26 @@
+# Adoption Checklist
+
+## Audit First
+
+- identify the current logging library or custom logger
+- identify current log file paths and operator expectations
+- identify whether console output is part of normal operation
+- identify whether success events already exist for CLI commands
+- identify whether startup and shutdown events already exist for services
+
+## Logging-Only First
+
+Prefer this sequence unless the user explicitly needs more on day one:
+
+1. add `sc-observability`
+2. wire `LoggerConfig::default_for(...)`
+3. adopt the `~/.<app>` house-style root or an explicit override
+4. replace or wrap the current logging entry points
+5. verify the active file path through `logger.health()`
+
+## Incremental Rollout
+
+- replace the highest-value lifecycle and error paths first
+- keep stable `target` and `action` naming from the beginning
+- defer routing and OTLP until logging-only behavior is stable
+- verify downstream log readers or shipping jobs if file paths change

--- a/.claude/skills/sc-observability-adopting/references/console-and-log-root.md
+++ b/.claude/skills/sc-observability-adopting/references/console-and-log-root.md
@@ -1,0 +1,53 @@
+# Console And Log Root
+
+## In-Code Log Root Override
+
+The standard setup passes an explicit `log_root` into
+`LoggerConfig::default_for(service, log_root)`.
+
+If the user wants a different default than `~/.<app>`, change that path in the
+app's configuration layer rather than changing the house style itself.
+
+## `SC_LOG_ROOT` Precedence
+
+`LoggerConfig::default_for(...)` uses `SC_LOG_ROOT` only when the provided
+`log_root` is empty.
+
+Practical rule:
+
+- explicit non-empty `log_root` wins
+- empty `log_root` allows `SC_LOG_ROOT` to take effect
+
+## Easiest Console Logging
+
+For simple stdout console logging:
+
+```rust
+config.enable_console_sink = true;
+```
+
+This uses the built-in `ConsoleSink::stdout()` path.
+
+## Stderr Console Logging
+
+If the user wants stderr console output, use `LoggerBuilder` and register
+`ConsoleSink::stderr()` explicitly:
+
+```rust
+use std::sync::Arc;
+
+use sc_observability::{ConsoleSink, LoggerBuilder, SinkRegistration};
+
+config.enable_console_sink = false;
+let mut builder = LoggerBuilder::new(config)?;
+builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+let logger = builder.build();
+```
+
+## Usage Modes
+
+- local development: file + console is often useful
+- long-running production service: file-only is the default baseline
+- CLI: file-only or file + stderr depending on operator preference
+
+Avoid enabling multiple console sinks accidentally.

--- a/.claude/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md
+++ b/.claude/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md
@@ -1,0 +1,25 @@
+# Migrate From Custom JSONL
+
+Use this reference when the project already writes its own structured JSONL
+logs or has a custom retained sink pipeline.
+
+## Inventory
+
+- current path layout
+- current schema fields
+- rotation and retention behavior
+- custom health or dropped-event accounting
+
+## Migration Strategy
+
+- compare the current schema with `LogEvent`
+- preserve required operational fields first
+- decide whether custom sink behavior should remain custom or can be replaced
+  by the built-in file sink
+- confirm path compatibility before changing active log locations
+
+## Watch Items
+
+- custom schemas often encode app-specific semantics in ad hoc fields
+- downstream tooling may depend on exact filenames or field names
+- custom health behavior may need explicit remapping to `logger.health()`

--- a/.claude/skills/sc-observability-adopting/references/migrate-from-log.md
+++ b/.claude/skills/sc-observability-adopting/references/migrate-from-log.md
@@ -1,0 +1,29 @@
+# Migrate From `log`
+
+Use this reference when the existing project is based on `log` macros plus a
+separate logger backend.
+
+## Inventory
+
+- which backend is active now
+- whether file layout is part of operator tooling
+- whether message formatting is structured or plain text
+- where warnings and errors originate today
+
+## Migration Strategy
+
+- replace backend-specific setup with `LoggerConfig::default_for(...)`
+- keep the log root decision explicit
+- introduce stable `target` and `action` names instead of free-form categories
+- migrate the highest-value paths first:
+  - startup
+  - shutdown
+  - warnings
+  - errors
+  - CLI success
+
+## Watch Items
+
+- existing macros may hide category naming drift
+- downstream tooling may assume older file locations
+- plain-text-only logs usually need a deliberate structured field model

--- a/.claude/skills/sc-observability-adopting/references/migrate-from-tracing.md
+++ b/.claude/skills/sc-observability-adopting/references/migrate-from-tracing.md
@@ -1,0 +1,26 @@
+# Migrate From `tracing`
+
+Use this reference when the existing project already uses `tracing` and
+`tracing-subscriber`.
+
+## Inventory
+
+- existing subscriber stack
+- existing file or console sinks
+- whether traces and logs are already exported remotely
+- whether structured fields already exist and how stable they are
+
+## Migration Strategy
+
+- decide whether the project needs only logging or also needs `sc-observe` and
+  `sc-observability-otlp`
+- preserve lifecycle and error coverage first
+- map tracing metadata into stable `target` and `action` names
+- avoid trying to replace logging, routing, and OTLP in one uncontrolled step
+
+## Watch Items
+
+- tracing setups often mix local logging and telemetry concerns
+- operator expectations may depend on subscriber-specific formatting
+- if OTLP already exists, confirm whether the migration should stop at
+  `sc-observability` first or move straight to the full stack

--- a/.claude/skills/sc-observability-adopting/references/standard-configuration.md
+++ b/.claude/skills/sc-observability-adopting/references/standard-configuration.md
@@ -1,0 +1,82 @@
+# Standard Configuration
+
+This reference defines the `sc-observability` house style used by these
+skills.
+
+## Scope
+
+This is a skill-defined downstream convention. It is not a built-in
+`sc-observability` crate default.
+
+`CONSUMING.md` shows `PathBuf::from("./observability")` as the minimal crate
+usage example. This skill layers the `~/.<app>` house style on top of that
+baseline for teams that want one consistent convention across apps.
+
+## Recommended Dependencies
+
+```toml
+[dependencies]
+sc-observability = "1"
+serde_json = "1"
+dirs = "6"
+```
+
+Add `sc-observability-types` directly only when:
+
+- implementing custom sinks
+- extending the shared types layer directly
+
+## Default Log Root
+
+Use `~/.<app>` as the default log root convention.
+
+With the built-in file sink, the resulting active file path becomes:
+
+```text
+~/.<app>/logs/<service>.log.jsonl
+```
+
+This works by setting `log_root` to the expanded home-relative directory. The
+crate's actual file layout rule remains:
+
+```text
+<log_root>/logs/<service>.log.jsonl
+```
+
+## Home Directory Expansion
+
+Generated starter code should use the `dirs` crate:
+
+```rust
+dirs::home_dir().map(|p| p.join(format!(".{app}")))
+```
+
+If a home directory cannot be resolved:
+
+- prefer an explicit app-provided path
+- or return a configuration error
+
+Do not silently assume an OS-specific fallback path.
+
+## Light Logging Baseline
+
+- built-in file sink enabled
+- built-in console sink disabled
+- warnings and errors always emitted
+- informational logging remains sparse and intentional
+- long-running apps emit startup and shutdown events
+- CLIs emit one success event per successful command
+- use stable `target` and `action` names
+
+## Runtime Verification
+
+Use `logger.health()` for runtime checks.
+
+At minimum, downstream apps should be able to inspect:
+
+- aggregate logger state
+- active log path
+- sink status
+
+`logger.health().active_log_path` is the standard way to confirm the resolved
+path at runtime.

--- a/.claude/skills/sc-observability-bootstrapping/SKILL.md
+++ b/.claude/skills/sc-observability-bootstrapping/SKILL.md
@@ -52,3 +52,13 @@ style token substitution using:
 - `{{SERVICE_NAME}}`
 - `{{ENABLE_STDOUT_CONSOLE}}`
 - `{{ENABLE_STDERR_CONSOLE}}`
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: none

--- a/.claude/skills/sc-observability-bootstrapping/SKILL.md
+++ b/.claude/skills/sc-observability-bootstrapping/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: sc-observability-bootstrapping
+description: Use when the user says things like "set up sc-observability in a new Rust project" or "add structured logging to a new Rust app". Bootstraps a new project with sc-observability from crates.io using the shared light-logging house style, ~/.<app> log roots, and a rendered starter template.
+---
+
+# SC-Observability Bootstrapping
+
+Use this skill for new Rust projects or repos that want to start with
+`sc-observability`.
+
+## Workflow
+
+1. Choose the lightest crate set that fits the request:
+   - logging only: `sc-observability`
+   - typed routing: `sc-observe`
+   - OTLP export: `sc-observability-otlp`
+2. Default to logging-only setup unless the user explicitly needs more on day
+   one.
+3. Apply the house style from
+   `references/standard-configuration.md`.
+4. Use `assets/observability.rs.j2` when the user wants starter code or
+   `sc-compose` generation.
+5. Use `references/console-and-log-root.md` for custom roots, console output,
+   and `SC_LOG_ROOT` precedence.
+
+## Required Guidance
+
+- `~/.<app>` is a skill-defined house style, not a crate default.
+- The crate file-layout rule remains `<log_root>/logs/<service>.log.jsonl`.
+- Add `sc-observability-types` directly only when implementing custom sinks or
+  extending the shared types layer.
+- Keep informational logging sparse by default:
+  - warnings and errors always emitted
+  - long-running apps log startup and shutdown
+  - CLIs log one success event per successful command
+
+## References
+
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+- `README.md`
+- `CONSUMING.md`
+
+## Template Asset
+
+- `assets/observability.rs.j2`
+
+The template is a tier-1 rendered starter artifact intended for `sc-compose`
+style token substitution using:
+
+- `{{APP_NAME}}`
+- `{{SERVICE_NAME}}`
+- `{{ENABLE_STDOUT_CONSOLE}}`
+- `{{ENABLE_STDERR_CONSOLE}}`

--- a/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -23,7 +23,7 @@ pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
     let log_root = default_log_root()?;
     let mut config = LoggerConfig::default_for(service.clone(), log_root);
 
-    // Only one console token should render true. If both do, stderr wins.
+    // Only one console token should render true. If both render true, stdout takes effect because ENABLE_STDOUT_CONSOLE is evaluated first.
     if ENABLE_STDOUT_CONSOLE {
         config.enable_console_sink = true;
     } else if ENABLE_STDERR_CONSOLE {

--- a/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -23,11 +23,10 @@ pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
     let log_root = default_log_root()?;
     let mut config = LoggerConfig::default_for(service.clone(), log_root);
 
+    // Only one console token should render true. If both do, stderr wins.
     if ENABLE_STDOUT_CONSOLE {
         config.enable_console_sink = true;
-    }
-
-    if ENABLE_STDERR_CONSOLE {
+    } else if ENABLE_STDERR_CONSOLE {
         config.enable_console_sink = false;
         let mut builder = LoggerBuilder::new(config)?;
         builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));

--- a/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -1,0 +1,107 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sc_observability::{
+    ActionName, ConsoleSink, Level, LogEvent, Logger, LoggerBuilder, LoggerConfig, OutcomeLabel,
+    ProcessIdentity, SchemaVersion, ServiceName, SinkRegistration, TargetCategory, Timestamp,
+    OBSERVATION_ENVELOPE_VERSION,
+};
+
+const APP_NAME: &str = "{{APP_NAME}}";
+const SERVICE_NAME: &str = "{{SERVICE_NAME}}";
+const ENABLE_STDOUT_CONSOLE: bool = {{ENABLE_STDOUT_CONSOLE}};
+const ENABLE_STDERR_CONSOLE: bool = {{ENABLE_STDERR_CONSOLE}};
+
+pub fn default_log_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    dirs::home_dir()
+        .map(|path| path.join(format!(".{APP_NAME}")))
+        .ok_or_else(|| "could not resolve home directory for default log root".into())
+}
+
+pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
+    let service = ServiceName::new(SERVICE_NAME)?;
+    let log_root = default_log_root()?;
+    let mut config = LoggerConfig::default_for(service.clone(), log_root);
+
+    if ENABLE_STDOUT_CONSOLE {
+        config.enable_console_sink = true;
+    }
+
+    if ENABLE_STDERR_CONSOLE {
+        config.enable_console_sink = false;
+        let mut builder = LoggerBuilder::new(config)?;
+        builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+        return Ok(builder.build());
+    }
+
+    Ok(Logger::new(config)?)
+}
+
+pub fn emit_service_started(logger: &Logger) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.lifecycle")?,
+        action: ActionName::new("service.started")?,
+        message: Some("service started".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn emit_service_stopping(logger: &Logger) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.lifecycle")?,
+        action: ActionName::new("service.stopping")?,
+        message: Some("service stopping".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn emit_cli_success(logger: &Logger, action_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.cli")?,
+        action: ActionName::new(action_name)?,
+        message: Some("command completed successfully".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn print_health(logger: &Logger) {
+    let health = logger.health();
+    println!("logger state: {:?}", health.state);
+    println!("active log path: {}", health.active_log_path.display());
+}

--- a/.claude/skills/sc-observability-bootstrapping/references/console-and-log-root.md
+++ b/.claude/skills/sc-observability-bootstrapping/references/console-and-log-root.md
@@ -1,0 +1,53 @@
+# Console And Log Root
+
+## In-Code Log Root Override
+
+The standard setup passes an explicit `log_root` into
+`LoggerConfig::default_for(service, log_root)`.
+
+If the user wants a different default than `~/.<app>`, change that path in the
+app's configuration layer rather than changing the house style itself.
+
+## `SC_LOG_ROOT` Precedence
+
+`LoggerConfig::default_for(...)` uses `SC_LOG_ROOT` only when the provided
+`log_root` is empty.
+
+Practical rule:
+
+- explicit non-empty `log_root` wins
+- empty `log_root` allows `SC_LOG_ROOT` to take effect
+
+## Easiest Console Logging
+
+For simple stdout console logging:
+
+```rust
+config.enable_console_sink = true;
+```
+
+This uses the built-in `ConsoleSink::stdout()` path.
+
+## Stderr Console Logging
+
+If the user wants stderr console output, use `LoggerBuilder` and register
+`ConsoleSink::stderr()` explicitly:
+
+```rust
+use std::sync::Arc;
+
+use sc_observability::{ConsoleSink, LoggerBuilder, SinkRegistration};
+
+config.enable_console_sink = false;
+let mut builder = LoggerBuilder::new(config)?;
+builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+let logger = builder.build();
+```
+
+## Usage Modes
+
+- local development: file + console is often useful
+- long-running production service: file-only is the default baseline
+- CLI: file-only or file + stderr depending on operator preference
+
+Avoid enabling multiple console sinks accidentally.

--- a/.claude/skills/sc-observability-bootstrapping/references/standard-configuration.md
+++ b/.claude/skills/sc-observability-bootstrapping/references/standard-configuration.md
@@ -1,0 +1,82 @@
+# Standard Configuration
+
+This reference defines the `sc-observability` house style used by these
+skills.
+
+## Scope
+
+This is a skill-defined downstream convention. It is not a built-in
+`sc-observability` crate default.
+
+`CONSUMING.md` shows `PathBuf::from("./observability")` as the minimal crate
+usage example. This skill layers the `~/.<app>` house style on top of that
+baseline for teams that want one consistent convention across apps.
+
+## Recommended Dependencies
+
+```toml
+[dependencies]
+sc-observability = "1"
+serde_json = "1"
+dirs = "6"
+```
+
+Add `sc-observability-types` directly only when:
+
+- implementing custom sinks
+- extending the shared types layer directly
+
+## Default Log Root
+
+Use `~/.<app>` as the default log root convention.
+
+With the built-in file sink, the resulting active file path becomes:
+
+```text
+~/.<app>/logs/<service>.log.jsonl
+```
+
+This works by setting `log_root` to the expanded home-relative directory. The
+crate's actual file layout rule remains:
+
+```text
+<log_root>/logs/<service>.log.jsonl
+```
+
+## Home Directory Expansion
+
+Generated starter code should use the `dirs` crate:
+
+```rust
+dirs::home_dir().map(|p| p.join(format!(".{app}")))
+```
+
+If a home directory cannot be resolved:
+
+- prefer an explicit app-provided path
+- or return a configuration error
+
+Do not silently assume an OS-specific fallback path.
+
+## Light Logging Baseline
+
+- built-in file sink enabled
+- built-in console sink disabled
+- warnings and errors always emitted
+- informational logging remains sparse and intentional
+- long-running apps emit startup and shutdown events
+- CLIs emit one success event per successful command
+- use stable `target` and `action` names
+
+## Runtime Verification
+
+Use `logger.health()` for runtime checks.
+
+At minimum, downstream apps should be able to inspect:
+
+- aggregate logger state
+- active log path
+- sink status
+
+`logger.health().active_log_path` is the standard way to confirm the resolved
+path at runtime.

--- a/.claude/skills/sc-observability-reviewing/SKILL.md
+++ b/.claude/skills/sc-observability-reviewing/SKILL.md
@@ -50,6 +50,6 @@ Reviewed against
 
 - `SKILL.md` stays concise: confirmed
 - detailed material lives in `references/`: confirmed
-- starter code lives in `assets/`: confirmed
+- no template assets required for this skill: confirmed
 - scope reductions made: remediation examples stay in `references/` so the
   review workflow stays short

--- a/.claude/skills/sc-observability-reviewing/SKILL.md
+++ b/.claude/skills/sc-observability-reviewing/SKILL.md
@@ -42,3 +42,14 @@ Keep findings concrete. Distinguish:
 - missing baseline
 - deliberate divergence
 - app-type-specific choice
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: remediation examples stay in `references/` so the
+  review workflow stays short

--- a/.claude/skills/sc-observability-reviewing/SKILL.md
+++ b/.claude/skills/sc-observability-reviewing/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: sc-observability-reviewing
+description: Use when the user says things like "review this project for sc-observability best practices" or "check whether our logging setup matches the sc-observability standard". Reviews a Rust project's observability setup against the shared house style and recommends missing baseline items and easy improvements.
+---
+
+# SC-Observability Reviewing
+
+Use this skill when a user wants a focused review of a Rust project's logging
+or observability setup against the `sc-observability` house style.
+
+## Workflow
+
+1. Determine the app type:
+   - CLI
+   - long-running service
+   - hybrid tool
+2. Load `references/review-checklist.md`.
+3. Use `references/app-type-guidance.md` to adjust expectations by app type.
+4. Use `references/remediation-patterns.md` to turn gaps into concrete
+   recommendations.
+5. Prioritize recommendations:
+   - missing baseline items first
+   - then inconsistent conventions
+   - then optional improvements
+
+## Review Focus
+
+- crates.io adoption surface
+- log root and file path convention
+- override path and environment precedence
+- console setup path
+- warnings/errors coverage
+- service startup/shutdown coverage
+- CLI success-event coverage
+- stable naming for `target` and `action`
+- runtime verification through `logger.health()`
+
+## Output Rule
+
+Keep findings concrete. Distinguish:
+
+- missing baseline
+- deliberate divergence
+- app-type-specific choice

--- a/.claude/skills/sc-observability-reviewing/references/app-type-guidance.md
+++ b/.claude/skills/sc-observability-reviewing/references/app-type-guidance.md
@@ -1,0 +1,27 @@
+# App Type Guidance
+
+## CLI
+
+Expect:
+
+- sparse informational logging
+- one success event per successful command
+- errors and warnings always emitted
+- optional stderr console output for local/operator visibility
+
+## Long-Running Service
+
+Expect:
+
+- startup and shutdown events
+- file sink enabled by default
+- console sink off by default unless local development needs it
+- clear active log path verification
+
+## Hybrid Tool
+
+Expect:
+
+- explicit choice of service-like or CLI-like lifecycle behavior
+- avoid mixing verbose console output with quiet file logging by accident
+- keep target/action naming consistent across both modes

--- a/.claude/skills/sc-observability-reviewing/references/remediation-patterns.md
+++ b/.claude/skills/sc-observability-reviewing/references/remediation-patterns.md
@@ -1,0 +1,36 @@
+# Remediation Patterns
+
+## Missing Default Log Root
+
+Recommend:
+
+- introduce one configuration helper that resolves the app's default root
+- if following house style, use `dirs::home_dir()` and `~/.<app>`
+
+## Missing Console Path
+
+Recommend:
+
+- enable `config.enable_console_sink = true` for simple stdout console logging
+- use `LoggerBuilder` plus `ConsoleSink::stderr()` when stderr is preferred
+
+## Missing Lifecycle Events
+
+Recommend:
+
+- add service startup and shutdown events first
+- add a single CLI success event per successful command path
+
+## No Runtime Verification
+
+Recommend:
+
+- expose `logger.health()` in diagnostics or startup logs
+- inspect `active_log_path` during initialization
+
+## Naming Drift
+
+Recommend:
+
+- normalize `target` to subsystem-style namespaces
+- normalize `action` to stable verbs or lifecycle names

--- a/.claude/skills/sc-observability-reviewing/references/review-checklist.md
+++ b/.claude/skills/sc-observability-reviewing/references/review-checklist.md
@@ -1,0 +1,33 @@
+# Review Checklist
+
+## Baseline
+
+- `sc-observability` is used when the project wants the shared logging surface
+- `sc-observability-types` is only a direct dependency when actually needed
+- default file sink behavior is understood
+
+## Pathing
+
+- the project defines a default log root convention
+- if following house style, it resolves to `~/.<app>`
+- the resulting active path matches `<log_root>/logs/<service>.log.jsonl`
+- the app can verify the resolved path through `logger.health()`
+
+## Behavior
+
+- warnings and errors are always emitted
+- informational logging is not noisy by default
+- services log startup and shutdown
+- CLIs log one success event per successful command
+
+## Configuration
+
+- the log root can be overridden cleanly
+- `SC_LOG_ROOT` behavior is documented or understood
+- console output is easy to enable intentionally
+
+## Naming
+
+- `service` is stable
+- `target` is subsystem-oriented
+- `action` is stable and searchable

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -24,15 +24,14 @@ mod follow;
 mod health;
 mod jsonl_reader;
 mod query;
+mod redact;
+mod runtime;
+mod sinks;
 
-use std::fs::{self, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
-use crate::health::QueryHealthTracker;
 #[doc(inline)]
 pub use builder::LoggerBuilder;
 #[doc(inline)]
@@ -40,17 +39,20 @@ pub use follow::LogFollowSession;
 #[doc(inline)]
 pub use jsonl_reader::JsonlLogReader;
 #[doc(inline)]
+pub use sinks::{ConsoleSink, JsonlFileSink};
+#[cfg(feature = "fault-injection")]
+#[doc(inline)]
+pub use sinks::RetainedSinkFaultInjector;
+#[doc(inline)]
 pub use sc_observability_types::{
     ActionName, ErrorCode, EventError, Level, LogEvent, LogQuery, LogSnapshot, LoggingHealthReport,
     LoggingHealthState, OBSERVATION_ENVELOPE_VERSION, OutcomeLabel, ProcessIdentity, SchemaVersion,
     ServiceName, SinkHealth, SinkHealthState, TargetCategory, Timestamp,
 };
-use sc_observability_types::{
-    Diagnostic, DiagnosticInfo, DiagnosticSummary, ErrorContext, FlushError, InitError,
-    LevelFilter, LogSinkError, ProcessIdentityPolicy, QueryError, QueryHealthState, Remediation,
-    ShutdownError, SinkName,
-};
+use sc_observability_types::{LevelFilter, LogSinkError, ProcessIdentityPolicy};
 use serde_json::Value;
+
+pub(crate) use runtime::LoggerRuntime;
 
 /// Rotation limits for the built-in JSONL file sink.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -158,88 +160,6 @@ impl SinkRegistration {
     }
 }
 
-#[cfg(feature = "fault-injection")]
-/// Public controller for forcing retained sink health into validation states.
-///
-/// This type is intended for live validation and test harness use only. It
-/// wraps one existing retained sink and forces that sink to report degraded or
-/// unavailable health through the ordinary `LoggingHealthReport` path without
-/// sabotaging the filesystem or reaching into crate-private internals.
-#[derive(Clone, Default)]
-#[expect(
-    missing_debug_implementations,
-    reason = "fault injector state is a small validation-only mutex wrapper without a useful stable Debug contract"
-)]
-pub struct RetainedSinkFaultInjector {
-    forced_state: Arc<Mutex<Option<SinkHealthState>>>,
-}
-
-#[cfg(feature = "fault-injection")]
-impl RetainedSinkFaultInjector {
-    /// Creates a new injector with no forced sink fault.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Wraps one retained sink so its health can be forced during validation.
-    ///
-    /// `Arc<dyn LogSink>` is intentionally preserved in this public signature
-    /// because `SinkRegistration::new()` takes `Arc<dyn LogSink>` and this
-    /// helper exists solely to compose with that registration surface.
-    pub fn wrap(&self, sink: Arc<dyn LogSink>) -> Arc<dyn LogSink> {
-        Arc::new(FaultInjectingSink {
-            inner: sink,
-            forced_state: self.forced_state.clone(),
-        })
-    }
-
-    /// Forces the wrapped retained sink into the degraded-dropping state.
-    pub fn force_degraded(&self) {
-        self.set_state(SinkHealthState::DegradedDropping);
-    }
-
-    /// Forces the wrapped retained sink into the unavailable state.
-    pub fn force_unavailable(&self) {
-        self.set_state(SinkHealthState::Unavailable);
-    }
-
-    /// Clears any forced sink fault and returns the wrapped sink to normal
-    /// health reporting.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the retained-sink fault-state mutex has been poisoned.
-    pub fn clear(&self) {
-        *self
-            .forced_state
-            .lock()
-            .expect("retained sink fault state poisoned") = None;
-    }
-
-    fn set_state(&self, state: SinkHealthState) {
-        *self
-            .forced_state
-            .lock()
-            .expect("retained sink fault state poisoned") = Some(state);
-    }
-}
-
-#[cfg(feature = "fault-injection")]
-struct FaultInjectingSink {
-    inner: Arc<dyn LogSink>,
-    forced_state: Arc<Mutex<Option<SinkHealthState>>>,
-}
-
-#[cfg(feature = "fault-injection")]
-impl FaultInjectingSink {
-    fn current_state(&self) -> Option<SinkHealthState> {
-        *self
-            .forced_state
-            .lock()
-            .expect("retained sink fault state poisoned")
-    }
-}
-
 /// Public configuration for the lightweight logging runtime.
 #[derive(Debug)]
 pub struct LoggerConfig {
@@ -301,30 +221,6 @@ impl LoggerConfig {
     }
 }
 
-struct LoggerRuntime {
-    dropped_events_total: AtomicU64,
-    flush_errors_total: AtomicU64,
-    // MUTEX: sink failures update the shared last_error summary from multiple sinks and call paths;
-    // Mutex is sufficient because reads are rare and the value is replaced atomically as one unit.
-    last_error: Mutex<Option<DiagnosticSummary>>,
-    query_health: Arc<QueryHealthTracker>,
-}
-
-impl LoggerRuntime {
-    fn new(query_available: bool) -> Self {
-        Self {
-            dropped_events_total: AtomicU64::new(0),
-            flush_errors_total: AtomicU64::new(0),
-            last_error: Mutex::new(None),
-            query_health: Arc::new(QueryHealthTracker::new(if query_available {
-                QueryHealthState::Healthy
-            } else {
-                QueryHealthState::Unavailable
-            })),
-        }
-    }
-}
-
 /// Lightweight structured logging runtime with built-in query and follow support.
 #[expect(
     missing_debug_implementations,
@@ -336,537 +232,6 @@ pub struct Logger {
     shutdown: Arc<AtomicBool>,
     runtime: LoggerRuntime,
 }
-
-impl Logger {
-    /// Starts a construction-time builder for sink registration.
-    pub fn builder(config: LoggerConfig) -> Result<LoggerBuilder, InitError> {
-        LoggerBuilder::new(config)
-    }
-
-    /// Creates a logger with the configured built-in sinks and runtime state.
-    pub fn new(config: LoggerConfig) -> Result<Self, InitError> {
-        Ok(LoggerBuilder::new(config)?.build())
-    }
-
-    /// Emits one structured log event through the configured sinks.
-    pub fn emit(&self, event: LogEvent) -> Result<(), EventError> {
-        if self.shutdown.load(Ordering::SeqCst) {
-            return Err(EventError(Box::new(ErrorContext::new(
-                error_codes::LOGGER_SHUTDOWN,
-                "logger is shut down",
-                Remediation::not_recoverable("create a new logger before emitting"),
-            ))));
-        }
-
-        validate_event(&event, &self.config.service_name)?;
-        let redacted = self.redact_event(event);
-
-        for registration in &self.sinks {
-            if registration
-                .filter
-                .as_ref()
-                .is_some_and(|filter| !filter.accepts(&redacted))
-            {
-                continue;
-            }
-
-            if let Err(err) = registration.sink.write(&redacted) {
-                self.record_sink_failure(&err);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Flushes all registered sinks.
-    ///
-    /// Sink flush failures are absorbed into logger health and counters so the
-    /// caller can continue shutdown or health inspection without a secondary
-    /// runtime failure.
-    ///
-    /// # Panics
-    ///
-    /// Panics if an internal sink-health mutex has been poisoned while one of
-    /// the built-in sink implementations is updating its flush state.
-    pub fn flush(&self) -> Result<(), FlushError> {
-        if self.shutdown.load(Ordering::SeqCst) {
-            return Ok(());
-        }
-
-        self.flush_registered_sinks();
-        Ok(())
-    }
-
-    /// Queries the current JSONL log set synchronously using the shared query contract.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal query-health mutex has been poisoned while the
-    /// runtime records the result of this query.
-    pub fn query(&self, query: &LogQuery) -> Result<LogSnapshot, QueryError> {
-        let reader = self.query_reader()?;
-        let result = reader.query(query);
-        self.runtime.query_health.record_result(&result);
-        result
-    }
-
-    /// Starts a tail-style follow session from the current end of the visible log set.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal query-health mutex has been poisoned while the
-    /// runtime records the result of this follow-start operation.
-    pub fn follow(&self, query: LogQuery) -> Result<LogFollowSession, QueryError> {
-        let active_log_path = self.ensure_query_available()?;
-        let result = LogFollowSession::with_health(
-            active_log_path,
-            query,
-            self.runtime.query_health.clone(),
-            Some(self.shutdown.clone()),
-        );
-        self.runtime.query_health.record_result(&result);
-        result
-    }
-
-    fn flush_registered_sinks(&self) {
-        for registration in &self.sinks {
-            if let Err(err) = registration.sink.flush() {
-                self.record_flush_failure(&err);
-            }
-        }
-    }
-
-    /// Shuts the logger down and makes logger-owned query/follow unavailable.
-    ///
-    /// # Panics
-    ///
-    /// Panics if an internal sink-health mutex or the internal query-health
-    /// mutex has been poisoned while shutdown is flushing sinks and marking
-    /// query/follow unavailable.
-    pub fn shutdown(&self) -> Result<(), ShutdownError> {
-        if self.shutdown.swap(true, Ordering::SeqCst) {
-            return Ok(());
-        }
-
-        self.flush_registered_sinks();
-        self.runtime.query_health.mark_unavailable(None);
-        Ok(())
-    }
-
-    /// Returns aggregate logging and query/follow health for the runtime.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal last-error mutex has been poisoned.
-    pub fn health(&self) -> LoggingHealthReport {
-        let sink_statuses: Vec<SinkHealth> =
-            self.sinks.iter().map(|entry| entry.sink.health()).collect();
-        LoggingHealthReport {
-            state: aggregate_logging_health_state(&sink_statuses),
-            dropped_events_total: self.runtime.dropped_events_total.load(Ordering::SeqCst),
-            flush_errors_total: self.runtime.flush_errors_total.load(Ordering::SeqCst),
-            active_log_path: default_log_path(&self.config.log_root, &self.config.service_name),
-            sink_statuses,
-            query: Some(self.runtime.query_health.snapshot()),
-            last_error: self
-                .runtime
-                .last_error
-                .lock()
-                .expect("logger last_error poisoned")
-                .clone(),
-        }
-    }
-
-    fn redact_event(&self, mut event: LogEvent) -> LogEvent {
-        if self.config.redaction.redact_bearer_tokens
-            && let Some(message) = event.message.as_mut()
-        {
-            *message = redact_bearer_token_text(message);
-        }
-
-        for (key, value) in &mut event.fields {
-            if self
-                .config
-                .redaction
-                .denylist_keys
-                .iter()
-                .any(|deny| deny == key)
-            {
-                *value = Value::String(constants::REDACTED_VALUE.to_string());
-            }
-            if self.config.redaction.redact_bearer_tokens {
-                redact_string_value(value);
-            }
-            for redactor in &self.config.redaction.custom_redactors {
-                redactor.redact(key, value);
-            }
-        }
-
-        event
-    }
-
-    fn record_sink_failure(&self, error: &LogSinkError) {
-        self.runtime
-            .dropped_events_total
-            .fetch_add(1, Ordering::SeqCst);
-        *self
-            .runtime
-            .last_error
-            .lock()
-            .expect("logger last_error poisoned") =
-            Some(DiagnosticSummary::from(error.diagnostic()));
-    }
-
-    fn record_flush_failure(&self, error: &LogSinkError) {
-        self.runtime
-            .flush_errors_total
-            .fetch_add(1, Ordering::SeqCst);
-        *self
-            .runtime
-            .last_error
-            .lock()
-            .expect("logger last_error poisoned") =
-            Some(DiagnosticSummary::from(error.diagnostic()));
-    }
-
-    fn query_reader(&self) -> Result<JsonlLogReader, QueryError> {
-        self.ensure_query_available().map(JsonlLogReader::new)
-    }
-
-    fn ensure_query_available(&self) -> Result<PathBuf, QueryError> {
-        if self.shutdown.load(Ordering::SeqCst) {
-            let error = query::shutdown_error();
-            self.runtime.query_health.record_error(&error);
-            return Err(error);
-        }
-
-        if !self.config.enable_file_sink {
-            let error = query::unavailable_error(
-                "logger query/follow requires the built-in JSONL file sink to be enabled",
-            );
-            self.runtime.query_health.record_error(&error);
-            return Err(error);
-        }
-
-        Ok(default_log_path(
-            &self.config.log_root,
-            &self.config.service_name,
-        ))
-    }
-}
-
-/// Built-in JSONL file sink with rotation and retention handling.
-#[expect(
-    missing_debug_implementations,
-    reason = "file-sink internals include mutex-protected runtime state that is intentionally not exposed through a public Debug contract"
-)]
-pub struct JsonlFileSink {
-    path: PathBuf,
-    rotation: RotationPolicy,
-    retention: RetentionPolicy,
-    // MUTEX: sink health mutates as one small shared struct during writes and health reads;
-    // Mutex keeps updates simple and coherent, while RwLock would not reduce contention materially.
-    health: Mutex<SinkHealth>,
-}
-
-impl JsonlFileSink {
-    /// Creates a JSONL file sink at the given active log path.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the workspace-owned `JSONL_FILE_SINK_NAME` constant ever
-    /// becomes invalid for `SinkName`, which would indicate a programming bug.
-    pub fn new(path: PathBuf, rotation: RotationPolicy, retention: RetentionPolicy) -> Self {
-        Self {
-            path,
-            rotation,
-            retention,
-            health: Mutex::new(SinkHealth {
-                name: SinkName::new(constants::JSONL_FILE_SINK_NAME)
-                    .expect("jsonl sink constant is valid"),
-                state: SinkHealthState::Healthy,
-                last_error: None,
-            }),
-        }
-    }
-
-    /// Returns the active JSONL file path for the sink.
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "the helper preserves a Result-shaped internal API so rotation checks can grow I/O failure propagation without reshaping caller control flow"
-    )]
-    fn rotate_if_needed(&self, incoming_len: u64) -> Result<(), LogSinkError> {
-        if let Ok(metadata) = fs::metadata(&self.path)
-            && metadata.len().saturating_add(incoming_len) > self.rotation.max_bytes
-        {
-            for idx in (1..self.rotation.max_files).rev() {
-                let src = self.rotated_path(idx);
-                let dest = self.rotated_path(idx + 1);
-                // Rotation is best-effort: if a file is absent or another rename wins,
-                // later writes still succeed and the next rotation pass will heal state.
-                let _ = rename_if_present(&src, &dest);
-            }
-            let rotated = self.rotated_path(1);
-            // The active file rename is also best-effort so logging stays fail-open
-            // even when the platform cannot complete the rotation move immediately.
-            let _ = rename_if_present(&self.path, &rotated);
-        }
-
-        self.prune_old_files();
-        Ok(())
-    }
-
-    fn rotated_path(&self, index: u32) -> PathBuf {
-        rotated_log_path(&self.path, index)
-    }
-
-    fn prune_old_files(&self) {
-        let Some(parent) = self.path.parent() else {
-            return;
-        };
-
-        let Ok(entries) = fs::read_dir(parent) else {
-            return;
-        };
-        let retention_cutoff = SystemTime::now()
-            - Duration::from_secs(u64::from(self.retention.max_age_days) * constants::SECS_PER_DAY);
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
-                continue;
-            };
-
-            let active_name = self
-                .path
-                .file_name()
-                .and_then(|value| value.to_str())
-                .unwrap_or_default();
-
-            if !file_name.starts_with(active_name) || file_name == active_name {
-                continue;
-            }
-
-            if let Ok(metadata) = entry.metadata()
-                && let Ok(modified) = metadata.modified()
-                && modified < retention_cutoff
-            {
-                // Retention cleanup is best-effort: failure to delete an old file should not
-                // block new writes or turn routine pruning into a runtime error.
-                let _ = fs::remove_file(path);
-            }
-        }
-    }
-
-    fn mark_failure<E>(&self, error: E) -> LogSinkError
-    where
-        E: std::error::Error + Send + Sync + 'static,
-    {
-        let message = error.to_string();
-        let diagnostic = diagnostic_for_sink_failure(message.clone());
-        let mut health = self.health.lock().expect("file sink health poisoned");
-        health.state = SinkHealthState::DegradedDropping;
-        health.last_error = Some(DiagnosticSummary::from(&diagnostic));
-        LogSinkError(Box::new(
-            ErrorContext::new(
-                error_codes::LOGGER_SINK_WRITE_FAILED,
-                "jsonl file sink write failed",
-                Remediation::not_recoverable(
-                    "file sink write failure handling is owned by the logger runtime",
-                ),
-            )
-            .cause(message)
-            .source(Box::new(error)),
-        ))
-    }
-}
-
-impl LogSink for JsonlFileSink {
-    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).map_err(|err| self.mark_failure(err))?;
-        }
-
-        let mut line = serde_json::to_vec(event).map_err(|err| self.mark_failure(err))?;
-        line.push(b'\n');
-        self.rotate_if_needed(line.len() as u64)?;
-
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
-            .map_err(|err| self.mark_failure(err))?;
-        file.write_all(&line)
-            .and_then(|()| file.flush())
-            .map_err(|err| self.mark_failure(err))?;
-
-        let mut health = self.health.lock().expect("file sink health poisoned");
-        health.state = SinkHealthState::Healthy;
-        Ok(())
-    }
-
-    fn health(&self) -> SinkHealth {
-        self.health
-            .lock()
-            .expect("file sink health poisoned")
-            .clone()
-    }
-}
-
-trait ConsoleWriter: Send + Sync {
-    fn write_line(&self, line: &str) -> std::io::Result<()>;
-}
-
-struct StdoutConsoleWriter;
-
-impl ConsoleWriter for StdoutConsoleWriter {
-    fn write_line(&self, line: &str) -> std::io::Result<()> {
-        let mut stdout = std::io::stdout().lock();
-        stdout.write_all(line.as_bytes())?;
-        stdout.write_all(b"\n")?;
-        stdout.flush()
-    }
-}
-
-struct StderrConsoleWriter;
-
-impl ConsoleWriter for StderrConsoleWriter {
-    fn write_line(&self, line: &str) -> std::io::Result<()> {
-        let mut stderr = std::io::stderr().lock();
-        stderr.write_all(line.as_bytes())?;
-        stderr.write_all(b"\n")?;
-        stderr.flush()
-    }
-}
-
-/// Built-in sink that renders log events to a configured output stream
-/// (stdout or stderr).
-#[expect(
-    missing_debug_implementations,
-    reason = "console sink owns a trait-object writer and sink health state, so a derived Debug impl would not be stable or useful"
-)]
-pub struct ConsoleSink {
-    writer: Box<dyn ConsoleWriter>,
-    // MUTEX: console sink health mutates as one shared status struct on write failures and reads;
-    // Mutex is simpler than RwLock because writes dominate and the payload is tiny.
-    health: Mutex<SinkHealth>,
-}
-
-impl ConsoleSink {
-    /// Creates a console sink backed by stdout.
-    pub fn stdout() -> Self {
-        Self::from_writer(Box::new(StdoutConsoleWriter))
-    }
-
-    /// Creates a console sink backed by stderr.
-    pub fn stderr() -> Self {
-        Self::from_writer(Box::new(StderrConsoleWriter))
-    }
-
-    pub(crate) fn from_writer(writer: Box<dyn ConsoleWriter>) -> Self {
-        Self {
-            writer,
-            health: Mutex::new(SinkHealth {
-                name: SinkName::new(constants::CONSOLE_SINK_NAME)
-                    .expect("console sink constant is valid"),
-                state: SinkHealthState::Healthy,
-                last_error: None,
-            }),
-        }
-    }
-
-    fn format_line(event: &LogEvent) -> String {
-        let level = match event.level {
-            Level::Trace => "TRACE",
-            Level::Debug => "DEBUG",
-            Level::Info => "INFO",
-            Level::Warn => "WARN",
-            Level::Error => "ERROR",
-        };
-        let message = event.message.as_deref().unwrap_or("");
-        format!(
-            "{} {} {} {} {}",
-            event.timestamp,
-            level,
-            event.target.as_str(),
-            event.action.as_str(),
-            message
-        )
-    }
-
-    fn mark_failure<E>(&self, error: E) -> LogSinkError
-    where
-        E: std::error::Error + Send + Sync + 'static,
-    {
-        let message = error.to_string();
-        let diagnostic = diagnostic_for_sink_failure(message.clone());
-        let mut health = self.health.lock().expect("console sink health poisoned");
-        health.state = SinkHealthState::DegradedDropping;
-        health.last_error = Some(DiagnosticSummary::from(&diagnostic));
-        LogSinkError(Box::new(
-            ErrorContext::new(
-                error_codes::LOGGER_SINK_WRITE_FAILED,
-                "console sink write failed",
-                Remediation::not_recoverable(
-                    "console sink write failure handling is owned by the logger runtime",
-                ),
-            )
-            .cause(message)
-            .source(Box::new(error)),
-        ))
-    }
-}
-
-impl LogSink for ConsoleSink {
-    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
-        let line = Self::format_line(event);
-        self.writer
-            .write_line(&line)
-            .map_err(|err| self.mark_failure(err))?;
-        let mut health = self.health.lock().expect("console sink health poisoned");
-        health.state = SinkHealthState::Healthy;
-        Ok(())
-    }
-
-    fn health(&self) -> SinkHealth {
-        self.health
-            .lock()
-            .expect("console sink health poisoned")
-            .clone()
-    }
-}
-
-#[cfg(feature = "fault-injection")]
-impl LogSink for FaultInjectingSink {
-    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
-        if let Some(state) = self.current_state() {
-            return Err(LogSinkError(Box::new(fault_injection_error_context(state))));
-        }
-        self.inner.write(event)
-    }
-
-    fn flush(&self) -> Result<(), LogSinkError> {
-        if let Some(state) = self.current_state() {
-            return Err(LogSinkError(Box::new(fault_injection_error_context(state))));
-        }
-        self.inner.flush()
-    }
-
-    fn health(&self) -> SinkHealth {
-        let mut health = self.inner.health();
-        if let Some(state) = self.current_state() {
-            let context = fault_injection_error_context(state);
-            health.state = state;
-            health.last_error = Some(DiagnosticSummary::from(context.diagnostic()));
-        }
-        health
-    }
-}
-
 mod sealed_emitters {
     pub trait Sealed {}
 }
@@ -885,46 +250,6 @@ impl LogEmitter for Logger {
     fn emit_log(&self, event: LogEvent) -> Result<(), EventError> {
         self.emit(event)
     }
-}
-
-pub(crate) fn diagnostic_for_sink_failure(message: impl Into<String>) -> Diagnostic {
-    Diagnostic {
-        timestamp: Timestamp::now_utc(),
-        code: error_codes::LOGGER_SINK_WRITE_FAILED,
-        message: message.into(),
-        cause: None,
-        remediation: Remediation::not_recoverable(
-            "sink failure handling is owned by the logger runtime",
-        ),
-        docs: None,
-        details: serde_json::Map::new(),
-    }
-}
-
-fn validate_event(event: &LogEvent, expected_service: &ServiceName) -> Result<(), EventError> {
-    if event.version.as_str() != sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION {
-        return Err(EventError(Box::new(ErrorContext::new(
-            error_codes::LOGGER_INVALID_EVENT,
-            "log event version is invalid",
-            Remediation::recoverable(
-                "emit an observation v1 log event",
-                ["recreate the event with the current contract"],
-            ),
-        ))));
-    }
-
-    if &event.service != expected_service {
-        return Err(EventError(Box::new(ErrorContext::new(
-            error_codes::LOGGER_INVALID_EVENT,
-            "log event service does not match logger service",
-            Remediation::recoverable(
-                "emit the event with the logger service name",
-                ["rebuild the event before emitting"],
-            ),
-        ))));
-    }
-
-    Ok(())
 }
 
 pub(crate) fn default_log_file_name(service_name: &ServiceName) -> String {
@@ -950,82 +275,20 @@ pub(crate) fn rotated_log_path(active_path: &Path, index: u32) -> PathBuf {
     parent.join(format!("{file_name}.{index}"))
 }
 
-fn aggregate_logging_health_state(sink_statuses: &[SinkHealth]) -> LoggingHealthState {
-    if sink_statuses
-        .iter()
-        .any(|sink| sink.state == SinkHealthState::Unavailable)
-    {
-        LoggingHealthState::Unavailable
-    } else if sink_statuses
-        .iter()
-        .any(|sink| sink.state != SinkHealthState::Healthy)
-    {
-        LoggingHealthState::DegradedDropping
-    } else {
-        LoggingHealthState::Healthy
-    }
-}
-
-#[cfg(feature = "fault-injection")]
-fn fault_injection_error_context(state: SinkHealthState) -> ErrorContext {
-    let forced_state = match state {
-        SinkHealthState::Healthy => "healthy",
-        SinkHealthState::DegradedDropping => "degraded_dropping",
-        SinkHealthState::Unavailable => "unavailable",
-    };
-    ErrorContext::new(
-        error_codes::LOGGER_SINK_FAULT_INJECTED,
-        format!("retained sink fault injection forced {forced_state} state"),
-        Remediation::recoverable(
-            "clear the retained sink fault injector before resuming normal validation traffic",
-            ["clear the injector state"],
-        ),
-    )
-    .detail("forced_state", Value::String(forced_state.to_string()))
-}
-
-fn rename_if_present(src: &Path, dest: &Path) -> std::io::Result<()> {
-    match fs::rename(src, dest) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err),
-    }
-}
-
-fn redact_string_value(value: &mut Value) {
-    if let Value::String(text) = value {
-        *text = redact_bearer_token_text(text);
-    }
-}
-
-fn redact_bearer_token_text(input: &str) -> String {
-    const PREFIX: &str = "Bearer ";
-    let mut result = String::with_capacity(input.len());
-    let mut remaining = input;
-
-    while let Some(index) = remaining.find(PREFIX) {
-        result.push_str(&remaining[..index + PREFIX.len()]);
-        let token_start = index + PREFIX.len();
-        let token_end = remaining[token_start..]
-            .find(char::is_whitespace)
-            .map_or(remaining.len(), |value| token_start + value);
-        result.push_str(constants::REDACTED_VALUE);
-        remaining = &remaining[token_end..];
-    }
-
-    result.push_str(remaining);
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sinks::ConsoleWriter;
     use sc_observability_types::{
-        ActionName, Diagnostic, ErrorCode, Level, LogEvent, LogOrder, LogQuery, LogSnapshot,
-        ProcessIdentity, QueryError, QueryHealthState, TargetCategory, Timestamp,
+        ActionName, Diagnostic, ErrorCode, ErrorContext, Level, LogEvent, LogOrder, LogQuery,
+        LogSnapshot, ProcessIdentity, QueryError, QueryHealthState, Remediation, SinkName,
+        TargetCategory, Timestamp,
     };
     use serde_json::{Map, json};
-    use std::sync::Arc;
+    use std::fs::{self, OpenOptions};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::SystemTime;
     use temp_env::{with_var, with_var_unset};
 
     struct SharedBuffer {

--- a/crates/sc-observability/src/redact.rs
+++ b/crates/sc-observability/src/redact.rs
@@ -1,0 +1,28 @@
+use serde_json::Value;
+
+use crate::constants;
+
+pub(crate) fn redact_string_value(value: &mut Value) {
+    if let Value::String(text) = value {
+        *text = redact_bearer_token_text(text);
+    }
+}
+
+pub(crate) fn redact_bearer_token_text(input: &str) -> String {
+    const PREFIX: &str = "Bearer ";
+    let mut result = String::with_capacity(input.len());
+    let mut remaining = input;
+
+    while let Some(index) = remaining.find(PREFIX) {
+        result.push_str(&remaining[..index + PREFIX.len()]);
+        let token_start = index + PREFIX.len();
+        let token_end = remaining[token_start..]
+            .find(char::is_whitespace)
+            .map_or(remaining.len(), |value| token_start + value);
+        result.push_str(constants::REDACTED_VALUE);
+        remaining = &remaining[token_end..];
+    }
+
+    result.push_str(remaining);
+    result
+}

--- a/crates/sc-observability/src/runtime.rs
+++ b/crates/sc-observability/src/runtime.rs
@@ -1,0 +1,299 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use sc_observability_types::{
+    DiagnosticInfo, DiagnosticSummary, ErrorContext, EventError, FlushError, LoggingHealthReport,
+    LoggingHealthState, LogQuery, LogSnapshot, QueryError, QueryHealthState, Remediation,
+    ShutdownError, SinkHealth, SinkHealthState,
+};
+use serde_json::Value;
+
+use crate::builder::LoggerBuilder;
+use crate::follow::LogFollowSession;
+use crate::health::QueryHealthTracker;
+use crate::jsonl_reader::JsonlLogReader;
+use crate::redact::{redact_bearer_token_text, redact_string_value};
+use crate::{LogEvent, LogSinkError, Logger, ServiceName, default_log_path, error_codes};
+
+pub(crate) struct LoggerRuntime {
+    pub(crate) dropped_events_total: AtomicU64,
+    pub(crate) flush_errors_total: AtomicU64,
+    pub(crate) last_error: Mutex<Option<DiagnosticSummary>>,
+    pub(crate) query_health: Arc<QueryHealthTracker>,
+}
+
+impl LoggerRuntime {
+    pub(crate) fn new(query_available: bool) -> Self {
+        Self {
+            dropped_events_total: AtomicU64::new(0),
+            flush_errors_total: AtomicU64::new(0),
+            last_error: Mutex::new(None),
+            query_health: Arc::new(QueryHealthTracker::new(if query_available {
+                QueryHealthState::Healthy
+            } else {
+                QueryHealthState::Unavailable
+            })),
+        }
+    }
+}
+
+impl Logger {
+    /// Starts a construction-time builder for sink registration.
+    pub fn builder(config: crate::LoggerConfig) -> Result<LoggerBuilder, sc_observability_types::InitError> {
+        LoggerBuilder::new(config)
+    }
+
+    /// Creates a logger with the configured built-in sinks and runtime state.
+    pub fn new(config: crate::LoggerConfig) -> Result<Self, sc_observability_types::InitError> {
+        Ok(LoggerBuilder::new(config)?.build())
+    }
+
+    /// Emits one structured log event through the configured sinks.
+    pub fn emit(&self, event: LogEvent) -> Result<(), EventError> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            return Err(EventError(Box::new(ErrorContext::new(
+                error_codes::LOGGER_SHUTDOWN,
+                "logger is shut down",
+                Remediation::not_recoverable("create a new logger before emitting"),
+            ))));
+        }
+
+        validate_event(&event, &self.config.service_name)?;
+        let redacted = self.redact_event(event);
+
+        for registration in &self.sinks {
+            if registration
+                .filter
+                .as_ref()
+                .is_some_and(|filter| !filter.accepts(&redacted))
+            {
+                continue;
+            }
+
+            if let Err(err) = registration.sink.write(&redacted) {
+                self.record_sink_failure(&err);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Flushes all registered sinks.
+    ///
+    /// Sink flush failures are absorbed into logger health and counters so the
+    /// caller can continue shutdown or health inspection without a secondary
+    /// runtime failure.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an internal sink-health mutex has been poisoned while one of
+    /// the built-in sink implementations is updating its flush state.
+    pub fn flush(&self) -> Result<(), FlushError> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        self.flush_registered_sinks();
+        Ok(())
+    }
+
+    /// Queries the current JSONL log set synchronously using the shared query contract.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal query-health mutex has been poisoned while the
+    /// runtime records the result of this query.
+    pub fn query(&self, query: &LogQuery) -> Result<LogSnapshot, QueryError> {
+        let reader = self.query_reader()?;
+        let result = reader.query(query);
+        self.runtime.query_health.record_result(&result);
+        result
+    }
+
+    /// Starts a tail-style follow session from the current end of the visible log set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal query-health mutex has been poisoned while the
+    /// runtime records the result of this follow-start operation.
+    pub fn follow(&self, query: LogQuery) -> Result<LogFollowSession, QueryError> {
+        let active_log_path = self.ensure_query_available()?;
+        let result = LogFollowSession::with_health(
+            active_log_path,
+            query,
+            self.runtime.query_health.clone(),
+            Some(self.shutdown.clone()),
+        );
+        self.runtime.query_health.record_result(&result);
+        result
+    }
+
+    /// Shuts the logger down and makes logger-owned query/follow unavailable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an internal sink-health mutex or the internal query-health
+    /// mutex has been poisoned while shutdown is flushing sinks and marking
+    /// query/follow unavailable.
+    pub fn shutdown(&self) -> Result<(), ShutdownError> {
+        if self.shutdown.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        self.flush_registered_sinks();
+        self.runtime.query_health.mark_unavailable(None);
+        Ok(())
+    }
+
+    /// Returns aggregate logging and query/follow health for the runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal last-error mutex has been poisoned.
+    pub fn health(&self) -> LoggingHealthReport {
+        let sink_statuses: Vec<SinkHealth> =
+            self.sinks.iter().map(|entry| entry.sink.health()).collect();
+        LoggingHealthReport {
+            state: aggregate_logging_health_state(&sink_statuses),
+            dropped_events_total: self.runtime.dropped_events_total.load(Ordering::SeqCst),
+            flush_errors_total: self.runtime.flush_errors_total.load(Ordering::SeqCst),
+            active_log_path: default_log_path(&self.config.log_root, &self.config.service_name),
+            sink_statuses,
+            query: Some(self.runtime.query_health.snapshot()),
+            last_error: self
+                .runtime
+                .last_error
+                .lock()
+                .expect("logger last_error poisoned")
+                .clone(),
+        }
+    }
+
+    fn flush_registered_sinks(&self) {
+        for registration in &self.sinks {
+            if let Err(err) = registration.sink.flush() {
+                self.record_flush_failure(&err);
+            }
+        }
+    }
+
+    fn redact_event(&self, mut event: LogEvent) -> LogEvent {
+        if self.config.redaction.redact_bearer_tokens
+            && let Some(message) = event.message.as_mut()
+        {
+            *message = redact_bearer_token_text(message);
+        }
+
+        for (key, value) in &mut event.fields {
+            if self
+                .config
+                .redaction
+                .denylist_keys
+                .iter()
+                .any(|deny| deny == key)
+            {
+                *value = Value::String(crate::constants::REDACTED_VALUE.to_string());
+            }
+            if self.config.redaction.redact_bearer_tokens {
+                redact_string_value(value);
+            }
+            for redactor in &self.config.redaction.custom_redactors {
+                redactor.redact(key, value);
+            }
+        }
+
+        event
+    }
+
+    fn record_sink_failure(&self, error: &LogSinkError) {
+        self.runtime
+            .dropped_events_total
+            .fetch_add(1, Ordering::SeqCst);
+        *self
+            .runtime
+            .last_error
+            .lock()
+            .expect("logger last_error poisoned") =
+            Some(DiagnosticSummary::from(error.diagnostic()));
+    }
+
+    fn record_flush_failure(&self, error: &LogSinkError) {
+        self.runtime
+            .flush_errors_total
+            .fetch_add(1, Ordering::SeqCst);
+        *self
+            .runtime
+            .last_error
+            .lock()
+            .expect("logger last_error poisoned") =
+            Some(DiagnosticSummary::from(error.diagnostic()));
+    }
+
+    fn query_reader(&self) -> Result<JsonlLogReader, QueryError> {
+        self.ensure_query_available().map(JsonlLogReader::new)
+    }
+
+    fn ensure_query_available(&self) -> Result<PathBuf, QueryError> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            let error = crate::query::shutdown_error();
+            self.runtime.query_health.record_error(&error);
+            return Err(error);
+        }
+
+        if !self.config.enable_file_sink {
+            let error = crate::query::unavailable_error(
+                "logger query/follow requires the built-in JSONL file sink to be enabled",
+            );
+            self.runtime.query_health.record_error(&error);
+            return Err(error);
+        }
+
+        Ok(default_log_path(
+            &self.config.log_root,
+            &self.config.service_name,
+        ))
+    }
+}
+
+fn aggregate_logging_health_state(sink_statuses: &[SinkHealth]) -> LoggingHealthState {
+    if sink_statuses
+        .iter()
+        .any(|sink| sink.state == SinkHealthState::Unavailable)
+    {
+        LoggingHealthState::Unavailable
+    } else if sink_statuses
+        .iter()
+        .any(|sink| sink.state != SinkHealthState::Healthy)
+    {
+        LoggingHealthState::DegradedDropping
+    } else {
+        LoggingHealthState::Healthy
+    }
+}
+
+fn validate_event(event: &LogEvent, expected_service: &ServiceName) -> Result<(), EventError> {
+    if event.version.as_str() != sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION {
+        return Err(EventError(Box::new(ErrorContext::new(
+            error_codes::LOGGER_INVALID_EVENT,
+            "log event version is invalid",
+            Remediation::recoverable(
+                "emit an observation v1 log event",
+                ["recreate the event with the current contract"],
+            ),
+        ))));
+    }
+
+    if &event.service != expected_service {
+        return Err(EventError(Box::new(ErrorContext::new(
+            error_codes::LOGGER_INVALID_EVENT,
+            "log event service does not match logger service",
+            Remediation::recoverable(
+                "emit the event with the logger service name",
+                ["rebuild the event before emitting"],
+            ),
+        ))));
+    }
+
+    Ok(())
+}

--- a/crates/sc-observability/src/sinks.rs
+++ b/crates/sc-observability/src/sinks.rs
@@ -10,8 +10,6 @@ use sc_observability_types::{
 };
 #[cfg(feature = "fault-injection")]
 use std::sync::Arc;
-#[cfg(feature = "fault-injection")]
-use sc_observability_types::DiagnosticInfo;
 
 use crate::{
     LogSink, RetentionPolicy, RotationPolicy, constants, error_codes, rotated_log_path,

--- a/crates/sc-observability/src/sinks.rs
+++ b/crates/sc-observability/src/sinks.rs
@@ -1,0 +1,445 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+use sc_observability_types::{
+    Diagnostic, DiagnosticSummary, ErrorContext, Level, LogEvent, LogSinkError, Remediation,
+    SinkHealth, SinkHealthState, SinkName, Timestamp,
+};
+#[cfg(feature = "fault-injection")]
+use std::sync::Arc;
+#[cfg(feature = "fault-injection")]
+use sc_observability_types::DiagnosticInfo;
+
+use crate::{
+    LogSink, RetentionPolicy, RotationPolicy, constants, error_codes, rotated_log_path,
+};
+
+#[expect(
+    missing_debug_implementations,
+    reason = "file-sink internals include mutex-protected runtime state that is intentionally not exposed through a public Debug contract"
+)]
+/// Built-in JSONL file sink with rotation and retention handling.
+pub struct JsonlFileSink {
+    path: PathBuf,
+    rotation: RotationPolicy,
+    retention: RetentionPolicy,
+    health: Mutex<SinkHealth>,
+}
+
+impl JsonlFileSink {
+    /// Creates a JSONL file sink at the given active log path.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the workspace-owned `JSONL_FILE_SINK_NAME` constant ever
+    /// becomes invalid for `SinkName`, which would indicate a programming bug.
+    pub fn new(path: PathBuf, rotation: RotationPolicy, retention: RetentionPolicy) -> Self {
+        Self {
+            path,
+            rotation,
+            retention,
+            health: Mutex::new(SinkHealth {
+                name: SinkName::new(constants::JSONL_FILE_SINK_NAME)
+                    .expect("jsonl sink constant is valid"),
+                state: SinkHealthState::Healthy,
+                last_error: None,
+            }),
+        }
+    }
+
+    /// Returns the active JSONL file path for the sink.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "the helper preserves a Result-shaped internal API so rotation checks can grow I/O failure propagation without reshaping caller control flow"
+    )]
+    fn rotate_if_needed(&self, incoming_len: u64) -> Result<(), LogSinkError> {
+        if let Ok(metadata) = fs::metadata(&self.path)
+            && metadata.len().saturating_add(incoming_len) > self.rotation.max_bytes
+        {
+            for idx in (1..self.rotation.max_files).rev() {
+                let src = self.rotated_path(idx);
+                let dest = self.rotated_path(idx + 1);
+                let _ = rename_if_present(&src, &dest);
+            }
+            let rotated = self.rotated_path(1);
+            let _ = rename_if_present(&self.path, &rotated);
+        }
+
+        self.prune_old_files();
+        Ok(())
+    }
+
+    pub(crate) fn rotated_path(&self, index: u32) -> PathBuf {
+        rotated_log_path(&self.path, index)
+    }
+
+    fn prune_old_files(&self) {
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+
+        let Ok(entries) = fs::read_dir(parent) else {
+            return;
+        };
+        let retention_cutoff = SystemTime::now()
+            - Duration::from_secs(u64::from(self.retention.max_age_days) * constants::SECS_PER_DAY);
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+
+            let active_name = self
+                .path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or_default();
+
+            if !file_name.starts_with(active_name) || file_name == active_name {
+                continue;
+            }
+
+            if let Ok(metadata) = entry.metadata()
+                && let Ok(modified) = metadata.modified()
+                && modified < retention_cutoff
+            {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+
+    fn mark_failure<E>(&self, error: E) -> LogSinkError
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let message = error.to_string();
+        let diagnostic = diagnostic_for_sink_failure(message.clone());
+        let mut health = self.health.lock().expect("file sink health poisoned");
+        health.state = SinkHealthState::DegradedDropping;
+        health.last_error = Some(DiagnosticSummary::from(&diagnostic));
+        LogSinkError(Box::new(
+            ErrorContext::new(
+                error_codes::LOGGER_SINK_WRITE_FAILED,
+                "jsonl file sink write failed",
+                Remediation::not_recoverable(
+                    "file sink write failure handling is owned by the logger runtime",
+                ),
+            )
+            .cause(message)
+            .source(Box::new(error)),
+        ))
+    }
+}
+
+impl LogSink for JsonlFileSink {
+    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|err| self.mark_failure(err))?;
+        }
+
+        let mut line = serde_json::to_vec(event).map_err(|err| self.mark_failure(err))?;
+        line.push(b'\n');
+        self.rotate_if_needed(line.len() as u64)?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|err| self.mark_failure(err))?;
+        file.write_all(&line)
+            .and_then(|()| file.flush())
+            .map_err(|err| self.mark_failure(err))?;
+
+        let mut health = self.health.lock().expect("file sink health poisoned");
+        health.state = SinkHealthState::Healthy;
+        Ok(())
+    }
+
+    fn health(&self) -> SinkHealth {
+        self.health
+            .lock()
+            .expect("file sink health poisoned")
+            .clone()
+    }
+}
+
+pub(crate) trait ConsoleWriter: Send + Sync {
+    fn write_line(&self, line: &str) -> std::io::Result<()>;
+}
+
+struct StdoutConsoleWriter;
+
+impl ConsoleWriter for StdoutConsoleWriter {
+    fn write_line(&self, line: &str) -> std::io::Result<()> {
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(line.as_bytes())?;
+        stdout.write_all(b"\n")?;
+        stdout.flush()
+    }
+}
+
+struct StderrConsoleWriter;
+
+impl ConsoleWriter for StderrConsoleWriter {
+    fn write_line(&self, line: &str) -> std::io::Result<()> {
+        let mut stderr = std::io::stderr().lock();
+        stderr.write_all(line.as_bytes())?;
+        stderr.write_all(b"\n")?;
+        stderr.flush()
+    }
+}
+
+#[expect(
+    missing_debug_implementations,
+    reason = "console sink owns a trait-object writer and sink health state, so a derived Debug impl would not be stable or useful"
+)]
+/// Built-in sink that renders log events to a configured output stream
+/// (stdout or stderr).
+pub struct ConsoleSink {
+    writer: Box<dyn ConsoleWriter>,
+    health: Mutex<SinkHealth>,
+}
+
+impl ConsoleSink {
+    /// Creates a console sink backed by stdout.
+    pub fn stdout() -> Self {
+        Self::from_writer(Box::new(StdoutConsoleWriter))
+    }
+
+    /// Creates a console sink backed by stderr.
+    pub fn stderr() -> Self {
+        Self::from_writer(Box::new(StderrConsoleWriter))
+    }
+
+    pub(crate) fn from_writer(writer: Box<dyn ConsoleWriter>) -> Self {
+        Self {
+            writer,
+            health: Mutex::new(SinkHealth {
+                name: SinkName::new(constants::CONSOLE_SINK_NAME)
+                    .expect("console sink constant is valid"),
+                state: SinkHealthState::Healthy,
+                last_error: None,
+            }),
+        }
+    }
+
+    fn format_line(event: &LogEvent) -> String {
+        let level = match event.level {
+            Level::Trace => "TRACE",
+            Level::Debug => "DEBUG",
+            Level::Info => "INFO",
+            Level::Warn => "WARN",
+            Level::Error => "ERROR",
+        };
+        let message = event.message.as_deref().unwrap_or("");
+        format!(
+            "{} {} {} {} {}",
+            event.timestamp,
+            level,
+            event.target.as_str(),
+            event.action.as_str(),
+            message
+        )
+    }
+
+    fn mark_failure<E>(&self, error: E) -> LogSinkError
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let message = error.to_string();
+        let diagnostic = diagnostic_for_sink_failure(message.clone());
+        let mut health = self.health.lock().expect("console sink health poisoned");
+        health.state = SinkHealthState::DegradedDropping;
+        health.last_error = Some(DiagnosticSummary::from(&diagnostic));
+        LogSinkError(Box::new(
+            ErrorContext::new(
+                error_codes::LOGGER_SINK_WRITE_FAILED,
+                "console sink write failed",
+                Remediation::not_recoverable(
+                    "console sink write failure handling is owned by the logger runtime",
+                ),
+            )
+            .cause(message)
+            .source(Box::new(error)),
+        ))
+    }
+}
+
+impl LogSink for ConsoleSink {
+    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
+        let line = Self::format_line(event);
+        self.writer
+            .write_line(&line)
+            .map_err(|err| self.mark_failure(err))?;
+        let mut health = self.health.lock().expect("console sink health poisoned");
+        health.state = SinkHealthState::Healthy;
+        Ok(())
+    }
+
+    fn health(&self) -> SinkHealth {
+        self.health
+            .lock()
+            .expect("console sink health poisoned")
+            .clone()
+    }
+}
+
+#[cfg(feature = "fault-injection")]
+#[derive(Clone, Default)]
+#[expect(
+    missing_debug_implementations,
+    reason = "fault injector state is a small validation-only mutex wrapper without a useful stable Debug contract"
+)]
+/// Public controller for forcing retained sink health into validation states.
+///
+/// This type is intended for live validation and test harness use only. It
+/// wraps one existing retained sink and forces that sink to report degraded or
+/// unavailable health through the ordinary `LoggingHealthReport` path without
+/// sabotaging the filesystem or reaching into crate-private internals.
+pub struct RetainedSinkFaultInjector {
+    forced_state: Arc<Mutex<Option<SinkHealthState>>>,
+}
+
+#[cfg(feature = "fault-injection")]
+impl RetainedSinkFaultInjector {
+    /// Creates a new injector with no forced sink fault.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Wraps one retained sink so its health can be forced during validation.
+    ///
+    /// `Arc<dyn LogSink>` is intentionally preserved in this public signature
+    /// because `SinkRegistration::new()` takes `Arc<dyn LogSink>` and this
+    /// helper exists solely to compose with that registration surface.
+    pub fn wrap(&self, sink: Arc<dyn LogSink>) -> Arc<dyn LogSink> {
+        Arc::new(FaultInjectingSink {
+            inner: sink,
+            forced_state: self.forced_state.clone(),
+        })
+    }
+
+    /// Forces the wrapped retained sink into the degraded-dropping state.
+    pub fn force_degraded(&self) {
+        self.set_state(SinkHealthState::DegradedDropping);
+    }
+
+    /// Forces the wrapped retained sink into the unavailable state.
+    pub fn force_unavailable(&self) {
+        self.set_state(SinkHealthState::Unavailable);
+    }
+
+    /// Clears any forced sink fault and returns the wrapped sink to normal
+    /// health reporting.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the retained-sink fault-state mutex has been poisoned.
+    pub fn clear(&self) {
+        *self
+            .forced_state
+            .lock()
+            .expect("retained sink fault state poisoned") = None;
+    }
+
+    fn set_state(&self, state: SinkHealthState) {
+        *self
+            .forced_state
+            .lock()
+            .expect("retained sink fault state poisoned") = Some(state);
+    }
+}
+
+#[cfg(feature = "fault-injection")]
+pub(crate) struct FaultInjectingSink {
+    inner: Arc<dyn LogSink>,
+    forced_state: Arc<Mutex<Option<SinkHealthState>>>,
+}
+
+#[cfg(feature = "fault-injection")]
+impl FaultInjectingSink {
+    fn current_state(&self) -> Option<SinkHealthState> {
+        *self
+            .forced_state
+            .lock()
+            .expect("retained sink fault state poisoned")
+    }
+}
+
+#[cfg(feature = "fault-injection")]
+impl LogSink for FaultInjectingSink {
+    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
+        if let Some(state) = self.current_state() {
+            return Err(LogSinkError(Box::new(fault_injection_error_context(state))));
+        }
+        self.inner.write(event)
+    }
+
+    fn flush(&self) -> Result<(), LogSinkError> {
+        if let Some(state) = self.current_state() {
+            return Err(LogSinkError(Box::new(fault_injection_error_context(state))));
+        }
+        self.inner.flush()
+    }
+
+    fn health(&self) -> SinkHealth {
+        let mut health = self.inner.health();
+        if let Some(state) = self.current_state() {
+            let context = fault_injection_error_context(state);
+            health.state = state;
+            health.last_error = Some(DiagnosticSummary::from(context.diagnostic()));
+        }
+        health
+    }
+}
+
+pub(crate) fn diagnostic_for_sink_failure(message: impl Into<String>) -> Diagnostic {
+    Diagnostic {
+        timestamp: Timestamp::now_utc(),
+        code: error_codes::LOGGER_SINK_WRITE_FAILED,
+        message: message.into(),
+        cause: None,
+        remediation: Remediation::not_recoverable(
+            "sink failure handling is owned by the logger runtime",
+        ),
+        docs: None,
+        details: serde_json::Map::new(),
+    }
+}
+
+#[cfg(feature = "fault-injection")]
+fn fault_injection_error_context(state: SinkHealthState) -> ErrorContext {
+    let forced_state = match state {
+        SinkHealthState::Healthy => "healthy",
+        SinkHealthState::DegradedDropping => "degraded_dropping",
+        SinkHealthState::Unavailable => "unavailable",
+    };
+    ErrorContext::new(
+        error_codes::LOGGER_SINK_FAULT_INJECTED,
+        format!("retained sink fault injection forced {forced_state} state"),
+        Remediation::recoverable(
+            "clear the retained sink fault injector before resuming normal validation traffic",
+            ["clear the injector state"],
+        ),
+    )
+    .detail(
+        "forced_state",
+        serde_json::Value::String(forced_state.to_string()),
+    )
+}
+
+fn rename_if_present(src: &Path, dest: &Path) -> std::io::Result<()> {
+    match fs::rename(src, dest) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}

--- a/docs/registries/nuget/registry.json
+++ b/docs/registries/nuget/registry.json
@@ -1,0 +1,61 @@
+{
+  "version": "2.0.0",
+  "generated": "2026-05-10T00:00:00Z",
+  "repo": "randlee/sc-observability",
+  "marketplace": {
+    "name": "sc-observability",
+    "version": "1.0.0",
+    "status": "beta",
+    "url": "https://github.com/randlee/sc-observability"
+  },
+  "metadata": {
+    "registryVersion": "2.0.0",
+    "schemaVersion": "1.0.0",
+    "totalPackages": 1,
+    "totalCommands": 0,
+    "totalSkills": 3,
+    "totalAgents": 0,
+    "totalScripts": 0,
+    "categories": {
+      "tools": [
+        "sc-observability"
+      ]
+    }
+  },
+  "packages": {
+    "sc-observability": {
+      "name": "sc-observability",
+      "version": "1.0.0",
+      "status": "beta",
+      "tier": 1,
+      "description": "Skills for downstream sc-observability bootstrapping, adopting, and reviewing.",
+      "github": "randlee/sc-observability",
+      "repo": "https://github.com/randlee/sc-observability",
+      "path": "packages/sc-observability",
+      "readme": "https://raw.githubusercontent.com/randlee/sc-observability/main/packages/sc-observability/README.md",
+      "license": "MIT",
+      "author": {
+        "name": "randlee"
+      },
+      "tags": [
+        "rust",
+        "observability",
+        "logging",
+        "skills"
+      ],
+      "artifacts": {
+        "commands": 0,
+        "skills": 3,
+        "agents": 0,
+        "scripts": 0,
+        "schemas": 0
+      },
+      "dependencies": [],
+      "changelog": "https://raw.githubusercontent.com/randlee/sc-observability/main/packages/sc-observability/CHANGELOG.md",
+      "lastUpdated": "2026-05-10",
+      "dependents": []
+    }
+  },
+  "versionCompatibility": {},
+  "publishers": {}
+}

--- a/docs/sc-observability-skills-plan.md
+++ b/docs/sc-observability-skills-plan.md
@@ -29,7 +29,6 @@ This plan is constrained by the following source material and decisions:
   - `CONSUMING.md`
   - `docs/architecture.md`
   - `docs/requirements.md`
-  - `docs/migration-guide.md`
   - `docs/atm-quickstart.md`
 
 Accepted product decisions for this plan:
@@ -128,6 +127,12 @@ The standard house style is:
 - default log root is `~/.<app>`
 - the built-in file sink therefore writes to:
   `~/.<app>/logs/<service>.log.jsonl`
+- the `~` expansion mechanism for generated starter code is:
+  - recommend the consumer add the `dirs` crate
+  - resolve the root with `dirs::home_dir().map(|p| p.join(format!(\".{app}\")))`
+  - if no home directory can be resolved, fall back to an explicit app-provided
+    path or return a configuration error rather than silently assuming a
+    platform-specific default
 
 This is intentionally layered on top of the crate contract documented in
 `CONSUMING.md`, which defines the final sink layout as:
@@ -136,12 +141,16 @@ This is intentionally layered on top of the crate contract documented in
 
 The skill content must make it explicit that the repo-wide convention is to set
 `log_root` to `~/.<app>` by default, not to change the sink naming contract.
+It must also make it explicit that this is a skill-defined house style for
+downstream consumers, not a built-in `sc-observability` crate default.
 
 ### 5.2 Default Logging Behavior
 
 The standard baseline for downstream apps is:
 
 - use `sc-observability` from crates.io as the initial default
+- add `sc-observability-types` as a direct dependency only when the consumer is
+  implementing custom sinks or extending the shared types layer directly
 - start with logging-only adoption before routing or OTLP unless the user asks
   for a heavier stack
 - default to a light logging posture:
@@ -225,11 +234,15 @@ Required asset:
 
 Required template contents:
 - app-name-based default log root helper
+- home-directory expansion implemented with the recommended `dirs` crate
 - standard `LoggerConfig::default_for(...)` setup
 - easy switch for enabling console logging
 - example startup/shutdown events for long-running apps
 - example success event for CLIs
 - `logger.health()` usage including active path inspection
+- explicit indication that the template is rendered through `sc-compose` style
+  token substitution and is therefore a generated starter artifact, not a
+  static copied file
 
 Guideline evaluation step for this skill:
 1. review the finished skill against:
@@ -276,6 +289,8 @@ Scope rule:
 - the skill itself remains focused on adoption into an existing repo
 - library-specific migration details live in references, not in the core
   `SKILL.md`
+- the migration reference files are new writes for this package and are not
+  derived from the repo's ATM-scoped `docs/migration-guide.md`
 
 Guideline evaluation step for this skill:
 1. review the finished skill against:
@@ -341,6 +356,8 @@ Guideline evaluation step for this skill:
 This shared reference must define:
 
 - the house-style default `~/.<app>` log root
+- the recommended `dirs` crate dependency for home-directory resolution in
+  generated starter code
 - resulting file layout
 - default sinks
 - light logging expectations and boundaries
@@ -444,9 +461,11 @@ This file must:
 - declare tier based on actual install assumptions
 
 Expected tier for this phase:
-- tier `0` if the package is self-contained guidance and templates only
-- tier `1` only if required token substitution is introduced
-- do not claim a lower tier than the package really needs
+- tier `1`
+  because `observability.rs.j2` is a rendered starter template intended for
+  `sc-compose`-style token substitution at use time
+- do not describe this package as tier `0` unless the template is later changed
+  to a static non-rendered example artifact
 
 ### 9.5 Forwarding Guidance
 
@@ -485,6 +504,7 @@ sync tooling, but this plan does not require such tooling up front.
 5. Write shared reference content:
    - standard configuration
    - console/log-root guidance
+   - explicit `dirs`-based home-directory resolution guidance
 6. Write `observability.rs.j2`.
 7. Write `sc-observability-new-project/SKILL.md`.
 8. Evaluate the new-project skill against the Synaptic Canvas skill guidelines

--- a/docs/sc-observability-skills-plan.md
+++ b/docs/sc-observability-skills-plan.md
@@ -1,0 +1,541 @@
+# SC-Observability Skills and Marketplace Plan
+
+## 1. Purpose
+
+This document defines the implementation plan for a repo-local and marketplace-
+published `sc-observability` skill package.
+
+The package will provide three Claude Code skills:
+
+1. `sc-observability-new-project`
+2. `sc-observability-existing-project`
+3. `sc-observability-review`
+
+These skills are intended to help downstream Rust applications adopt the
+published `sc-observability` crates from crates.io with a consistent house
+style for structured logging, configuration, and review.
+
+## 2. Inputs And Constraints
+
+This plan is constrained by the following source material and decisions:
+
+- this repo's current local skill layout under `.claude/skills/`
+- the Synaptic Canvas skill and agent guidance:
+  `/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`
+- the Synaptic Canvas marketplace-forwarding guidance:
+  `/Users/randlee/Documents/github/synaptic-canvas/docs/marketplace-forwarding.md`
+- the current consumer-facing repo docs:
+  - `README.md`
+  - `CONSUMING.md`
+  - `docs/architecture.md`
+  - `docs/requirements.md`
+  - `docs/migration-guide.md`
+  - `docs/atm-quickstart.md`
+
+Accepted product decisions for this plan:
+
+- marketplace name: `sc-observability`
+- package name: `sc-observability`
+- the skills must exist in both:
+  - this repo's local `.claude/skills/` tree
+  - the marketplace package under `packages/sc-observability/skills/`
+- migration content is useful, but does not need to be a first-class skill in
+  this phase
+- a review skill must exist in the same package
+
+## 3. Marketplace Rule
+
+Per the Synaptic Canvas marketplace-forwarding guidance, this repo cannot
+technically "forward" installs to the Synaptic Canvas marketplace.
+
+The supported model is:
+
+1. publish a minimal independent marketplace in this repo
+2. document that users should add both marketplaces when they want both sets
+   of packages:
+   - `randlee/synaptic-canvas`
+   - `randlee/sc-observability`
+
+This plan therefore treats marketplace forwarding as a documentation and
+consumer-install pattern, not a technical dependency or inheritance mechanism.
+
+## 4. Deliverables
+
+### 4.1 Local Skill Tree
+
+The repo-local skill copy will live under `.claude/skills/`:
+
+- `.claude/skills/sc-observability-new-project/SKILL.md`
+- `.claude/skills/sc-observability-new-project/references/standard-configuration.md`
+- `.claude/skills/sc-observability-new-project/references/console-and-log-root.md`
+- `.claude/skills/sc-observability-new-project/assets/observability.rs.j2`
+- `.claude/skills/sc-observability-existing-project/SKILL.md`
+- `.claude/skills/sc-observability-existing-project/references/standard-configuration.md`
+- `.claude/skills/sc-observability-existing-project/references/console-and-log-root.md`
+- `.claude/skills/sc-observability-existing-project/references/adoption-checklist.md`
+- `.claude/skills/sc-observability-existing-project/references/migrate-from-log.md`
+- `.claude/skills/sc-observability-existing-project/references/migrate-from-tracing.md`
+- `.claude/skills/sc-observability-existing-project/references/migrate-from-custom-jsonl.md`
+- `.claude/skills/sc-observability-review/SKILL.md`
+- `.claude/skills/sc-observability-review/references/review-checklist.md`
+- `.claude/skills/sc-observability-review/references/remediation-patterns.md`
+- `.claude/skills/sc-observability-review/references/app-type-guidance.md`
+
+### 4.2 Marketplace Package
+
+The marketplace package copy will live under `packages/sc-observability/`:
+
+- `packages/sc-observability/.claude-plugin/plugin.json`
+- `packages/sc-observability/README.md`
+- `packages/sc-observability/CHANGELOG.md`
+- `packages/sc-observability/skills/sc-observability-new-project/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-new-project/references/standard-configuration.md`
+- `packages/sc-observability/skills/sc-observability-new-project/references/console-and-log-root.md`
+- `packages/sc-observability/skills/sc-observability-new-project/assets/observability.rs.j2`
+- `packages/sc-observability/skills/sc-observability-existing-project/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/standard-configuration.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/console-and-log-root.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/adoption-checklist.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-log.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-tracing.md`
+- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-custom-jsonl.md`
+- `packages/sc-observability/skills/sc-observability-review/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-review/references/review-checklist.md`
+- `packages/sc-observability/skills/sc-observability-review/references/remediation-patterns.md`
+- `packages/sc-observability/skills/sc-observability-review/references/app-type-guidance.md`
+
+### 4.3 Marketplace Metadata
+
+The minimal marketplace metadata set will include:
+
+- `.claude-plugin/marketplace.json`
+- `docs/registries/nuget/registry.json`
+- a package-level README and changelog suitable for registry metadata linkage
+
+The marketplace metadata must advertise one package, `sc-observability`, that
+contains three skills.
+
+## 5. Shared Standard Configuration
+
+The skills package must define one shared standard configuration model so apps
+use `sc-observability` consistently.
+
+### 5.1 Default Log Root Convention
+
+The standard house style is:
+
+- application config chooses a logical app name
+- default log root is `~/.<app>`
+- the built-in file sink therefore writes to:
+  `~/.<app>/logs/<service>.log.jsonl`
+
+This is intentionally layered on top of the crate contract documented in
+`CONSUMING.md`, which defines the final sink layout as:
+
+- `<log_root>/logs/<service>.log.jsonl`
+
+The skill content must make it explicit that the repo-wide convention is to set
+`log_root` to `~/.<app>` by default, not to change the sink naming contract.
+
+### 5.2 Default Logging Behavior
+
+The standard baseline for downstream apps is:
+
+- use `sc-observability` from crates.io as the initial default
+- start with logging-only adoption before routing or OTLP unless the user asks
+  for a heavier stack
+- default to a light logging posture:
+  - warnings and errors are always emitted
+  - informational logging is intentionally sparse by default
+  - informational events should focus on lifecycle and meaningful successful
+    operations rather than verbose step-by-step tracing
+- built-in file sink enabled by default
+- built-in console sink disabled by default
+- long-running applications emit startup and shutdown events
+- CLIs generally emit one successful completion event per successful command
+- `logger.health()` and `active_log_path` are the standard runtime verification
+  hooks
+
+### 5.3 Override And Console Rules
+
+The shared configuration references must define:
+
+- the standard method for overriding the default log root in code
+- how `SC_LOG_ROOT` interacts with explicit configuration
+- how to enable console logging quickly
+- when to use `ConsoleSink::stdout()` versus `ConsoleSink::stderr()`
+- when file-only, console-only, or file-plus-console operation is appropriate
+
+### 5.4 Naming Guidance
+
+The shared configuration references must define a basic event-naming house
+style:
+
+- `service` uses the app/service identity
+- `target` uses stable subsystem-style namespaces
+- `action` uses stable action names, not ad hoc prose
+- startup, shutdown, success, warning, and error events should be named
+  predictably enough to support consistent search and review
+
+## 6. Skill Design Rules
+
+All three skills must follow the Synaptic Canvas skill guidance:
+
+- keep `SKILL.md` concise and procedural
+- move detailed material to `references/`
+- put starter code in `assets/`
+- avoid unnecessary auxiliary docs
+- keep one-level reference discovery from `SKILL.md`
+- use skill metadata that clearly signals when the skill should trigger
+
+This phase does not require dedicated execution agents. The skills are guidance
+and composition assets first.
+
+If agent-backed execution is added later, it must be designed separately and
+validated against the same Synaptic Canvas architecture guidance.
+
+## 7. Skill Specifications
+
+### 7.1 `sc-observability-new-project`
+
+Purpose:
+- help a user set up a new Rust project or repo with `sc-observability` from
+  crates.io
+
+Primary workflow:
+1. choose the right crate layer:
+   - logging only: `sc-observability`
+   - typed routing: `sc-observe`
+   - OTLP: `sc-observability-otlp`
+2. recommend logging-only setup as the default starting path
+3. apply the standard configuration convention:
+   - default log root `~/.<app>`
+   - active file path `~/.<app>/logs/<service>.log.jsonl`
+4. provide a minimal setup recipe for dependencies and logger construction
+5. provide template-backed starter code through `observability.rs.j2`
+6. explain how to override the log root and enable console logging
+7. point to deeper repo docs only when needed
+
+Required references:
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+
+Required asset:
+- `assets/observability.rs.j2`
+
+Required template contents:
+- app-name-based default log root helper
+- standard `LoggerConfig::default_for(...)` setup
+- easy switch for enabling console logging
+- example startup/shutdown events for long-running apps
+- example success event for CLIs
+- `logger.health()` usage including active path inspection
+
+Guideline evaluation step for this skill:
+1. review the finished skill against:
+   `/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`
+2. confirm:
+   - metadata clearly describes trigger conditions
+   - `SKILL.md` stays concise
+   - detailed material lives in `references/`
+   - template code lives in `assets/`
+   - no unnecessary agent layer is introduced
+3. record any required reductions in scope or wording before the skill is
+   declared done
+
+### 7.2 `sc-observability-existing-project`
+
+Purpose:
+- help a user bring `sc-observability` into an existing Rust project without
+  overloading the base skill with full migration playbooks
+
+Primary workflow:
+1. inspect the current project shape
+2. decide whether logging-only adoption is enough
+3. apply the same standard configuration convention used by the new-project
+   skill
+4. provide an adoption checklist:
+   - dependency additions
+   - logger construction
+   - log root choice
+   - console behavior
+   - event naming
+   - runtime verification
+5. use migration references only when the current project already has a notable
+   logging surface
+
+Required references:
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+- `references/adoption-checklist.md`
+- `references/migrate-from-log.md`
+- `references/migrate-from-tracing.md`
+- `references/migrate-from-custom-jsonl.md`
+
+Scope rule:
+- the skill itself remains focused on adoption into an existing repo
+- library-specific migration details live in references, not in the core
+  `SKILL.md`
+
+Guideline evaluation step for this skill:
+1. review the finished skill against:
+   `/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`
+2. confirm:
+   - `SKILL.md` remains the high-level workflow and navigation layer
+   - migration details were pushed into references
+   - the skill does not collapse setup, migration, and review into one large
+     body
+   - reference files are one hop away from `SKILL.md`
+3. trim or split content further if the skill body grows beyond a lean
+   discovery-layer document
+
+### 7.3 `sc-observability-review`
+
+Purpose:
+- review a Rust project's observability setup against the `sc-observability`
+  house style and recommend missed or inconsistent items
+
+Primary workflow:
+1. determine app type:
+   - CLI
+   - long-running service
+   - hybrid tool
+2. inspect current logging and observability setup
+3. compare it to the standard configuration contract
+4. produce prioritized recommendations
+5. explicitly call out missing baseline items
+
+Review scope must cover:
+- use of `sc-observability` from crates.io where applicable
+- default log root convention
+- final log path expectation
+- log-root override method
+- console setup method
+- file sink defaults
+- warning and error coverage
+- startup/shutdown behavior for long-running apps
+- single success event pattern for CLIs
+- event naming consistency
+- runtime verification via `logger.health()` or equivalent checks
+
+Required references:
+- `references/review-checklist.md`
+- `references/remediation-patterns.md`
+- `references/app-type-guidance.md`
+
+Guideline evaluation step for this skill:
+1. review the finished skill against:
+   `/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`
+2. confirm:
+   - the skill is a review/discovery layer, not an overbuilt execution engine
+   - checklist details and remediation patterns live in references
+   - the `SKILL.md` body stays compact and decision-oriented
+   - the output guidance is specific enough to be actionable
+3. revise wording if the skill becomes a generic review skill instead of a
+   focused `sc-observability` review surface
+
+## 8. Reference Content Plan
+
+### 8.1 `standard-configuration.md`
+
+This shared reference must define:
+
+- the house-style default `~/.<app>` log root
+- resulting file layout
+- default sinks
+- light logging expectations and boundaries
+- warning/error expectations
+- startup/shutdown expectations for long-running apps
+- success-event expectations for CLIs
+- target/action naming rules
+- `logger.health()` verification pattern
+
+This file should be duplicated exactly between the relevant local and package
+copies unless a later sync mechanism is introduced.
+
+### 8.2 `console-and-log-root.md`
+
+This reference must define:
+
+- explicit in-code log-root override
+- `SC_LOG_ROOT` behavior and precedence
+- easy console enablement
+- `stdout()` versus `stderr()` guidance
+- common local-development versus production usage modes
+
+### 8.3 `adoption-checklist.md`
+
+This reference must define:
+
+- current-state audit items
+- dependency updates
+- config insertion points
+- expected runtime validation checks
+- rollout advice for incremental adoption
+
+### 8.4 Migration References
+
+These references are support material for existing-project use cases:
+
+- `migrate-from-log.md`
+- `migrate-from-tracing.md`
+- `migrate-from-custom-jsonl.md`
+
+They should explain:
+
+- what to inventory first
+- what can remain temporarily during adoption
+- what to replace with `sc-observability`
+- what ingestion/path/health assumptions need review
+
+### 8.5 Review References
+
+These references must support the review skill:
+
+- `review-checklist.md`
+- `remediation-patterns.md`
+- `app-type-guidance.md`
+
+They should let the review skill distinguish between:
+
+- a missing baseline
+- a deliberate divergence
+- an app-type-specific choice
+
+## 9. Marketplace Metadata Plan
+
+### 9.1 `.claude-plugin/marketplace.json`
+
+This file must:
+
+- register the repo as marketplace `sc-observability`
+- advertise one package named `sc-observability`
+- point the package source to `./packages/sc-observability`
+- include the required package metadata fields described by the Synaptic Canvas
+  marketplace guidance
+
+### 9.2 `packages/sc-observability/.claude-plugin/plugin.json`
+
+This file must:
+
+- define package name `sc-observability`
+- list the three skill artifacts
+- omit commands and agents unless they are intentionally added later
+
+### 9.3 Package README And Changelog
+
+The package-level `README.md` and `CHANGELOG.md` must exist so marketplace and
+registry metadata can point to real package documentation.
+
+The package README should cover:
+
+- what the `sc-observability` package contains
+- the three included skills
+- the independent-marketplace install model
+- the recommendation to add Synaptic Canvas separately when needed
+
+### 9.4 `docs/registries/nuget/registry.json`
+
+This file must:
+
+- advertise the `sc-observability` package
+- report the correct skill count
+- use the repo as the distribution source
+- declare tier based on actual install assumptions
+
+Expected tier for this phase:
+- tier `0` if the package is self-contained guidance and templates only
+- tier `1` only if required token substitution is introduced
+- do not claim a lower tier than the package really needs
+
+### 9.5 Forwarding Guidance
+
+The marketplace docs should explain:
+
+- users add this repo's marketplace independently
+- users add Synaptic Canvas separately when they want both sources
+- this repo does not proxy Synaptic Canvas packages
+
+## 10. Duplication And Sync Rule
+
+Because the skills must exist in both the repo-local `.claude/skills/` tree and
+the marketplace package, this phase must define a practical sync rule.
+
+Required rule for this phase:
+
+- local and marketplace skill copies start identical at creation time
+- every content change to a local skill must be mirrored into the package copy
+  in the same change set
+- the plan review must check both trees for drift before completion
+
+If drift becomes costly later, a follow-on task may introduce generation or
+sync tooling, but this plan does not require such tooling up front.
+
+## 11. Implementation Sequence
+
+1. Create this planning document.
+2. Create the minimal marketplace skeleton:
+   - `.claude-plugin/marketplace.json`
+   - `packages/sc-observability/.claude-plugin/plugin.json`
+   - `packages/sc-observability/README.md`
+   - `packages/sc-observability/CHANGELOG.md`
+   - `docs/registries/nuget/registry.json`
+3. Create the local skill directories.
+4. Create the marketplace package skill directories.
+5. Write shared reference content:
+   - standard configuration
+   - console/log-root guidance
+6. Write `observability.rs.j2`.
+7. Write `sc-observability-new-project/SKILL.md`.
+8. Evaluate the new-project skill against the Synaptic Canvas skill guidelines
+   and revise it.
+9. Write existing-project references and `SKILL.md`.
+10. Evaluate the existing-project skill against the Synaptic Canvas skill
+    guidelines and revise it.
+11. Write review references and `SKILL.md`.
+12. Evaluate the review skill against the Synaptic Canvas skill guidelines and
+    revise it.
+13. Review both trees for local/package parity.
+14. Validate marketplace metadata for correct package and artifact counts.
+15. Review the full package for completeness and trim any bloated skill bodies.
+
+## 12. Plan Review Step
+
+After the plan is written, perform a plan-review pass before implementation
+starts.
+
+The review must verify:
+
+- all three skills are accounted for
+- the standard configuration contract is explicit
+- log-root override and console guidance are explicit
+- the template is part of the plan
+- migration material is references-only in this phase
+- marketplace duplication is accounted for
+- metadata files are named explicitly
+- package README/changelog coverage is accounted for
+- guideline-evaluation steps exist for each skill
+- forwarding limitations are stated accurately
+
+If any detail is missing, update this plan before it is committed.
+
+## 13. Exit Criteria
+
+This plan is complete when:
+
+- the document captures the full artifact inventory
+- each skill has a defined purpose, workflow, and reference set
+- the standard configuration is defined as a first-class shared contract
+- per-skill Synaptic Canvas guideline-evaluation steps are included
+- marketplace and duplication rules are explicit
+- the plan-review pass is complete with any missing details corrected
+
+## 14. Non-Goals For This Phase
+
+This plan does not require:
+
+- a fourth migration skill
+- agent-backed execution helpers
+- automated sync tooling between local and package copies
+- a technical marketplace-forwarding mechanism
+- changes to the core `sc-observability` crate behavior itself

--- a/docs/sc-observability-skills-plan.md
+++ b/docs/sc-observability-skills-plan.md
@@ -7,9 +7,9 @@ published `sc-observability` skill package.
 
 The package will provide three Claude Code skills:
 
-1. `sc-observability-new-project`
-2. `sc-observability-existing-project`
-3. `sc-observability-review`
+1. `sc-observability-bootstrapping`
+2. `sc-observability-adopting`
+3. `sc-observability-reviewing`
 
 These skills are intended to help downstream Rust applications adopt the
 published `sc-observability` crates from crates.io with a consistent house
@@ -40,7 +40,7 @@ Accepted product decisions for this plan:
   - the marketplace package under `packages/sc-observability/skills/`
 - migration content is useful, but does not need to be a first-class skill in
   this phase
-- a review skill must exist in the same package
+- a reviewing skill must exist in the same package
 
 ## 3. Marketplace Rule
 
@@ -64,21 +64,21 @@ consumer-install pattern, not a technical dependency or inheritance mechanism.
 
 The repo-local skill copy will live under `.claude/skills/`:
 
-- `.claude/skills/sc-observability-new-project/SKILL.md`
-- `.claude/skills/sc-observability-new-project/references/standard-configuration.md`
-- `.claude/skills/sc-observability-new-project/references/console-and-log-root.md`
-- `.claude/skills/sc-observability-new-project/assets/observability.rs.j2`
-- `.claude/skills/sc-observability-existing-project/SKILL.md`
-- `.claude/skills/sc-observability-existing-project/references/standard-configuration.md`
-- `.claude/skills/sc-observability-existing-project/references/console-and-log-root.md`
-- `.claude/skills/sc-observability-existing-project/references/adoption-checklist.md`
-- `.claude/skills/sc-observability-existing-project/references/migrate-from-log.md`
-- `.claude/skills/sc-observability-existing-project/references/migrate-from-tracing.md`
-- `.claude/skills/sc-observability-existing-project/references/migrate-from-custom-jsonl.md`
-- `.claude/skills/sc-observability-review/SKILL.md`
-- `.claude/skills/sc-observability-review/references/review-checklist.md`
-- `.claude/skills/sc-observability-review/references/remediation-patterns.md`
-- `.claude/skills/sc-observability-review/references/app-type-guidance.md`
+- `.claude/skills/sc-observability-bootstrapping/SKILL.md`
+- `.claude/skills/sc-observability-bootstrapping/references/standard-configuration.md`
+- `.claude/skills/sc-observability-bootstrapping/references/console-and-log-root.md`
+- `.claude/skills/sc-observability-bootstrapping/assets/observability.rs.j2`
+- `.claude/skills/sc-observability-adopting/SKILL.md`
+- `.claude/skills/sc-observability-adopting/references/standard-configuration.md`
+- `.claude/skills/sc-observability-adopting/references/console-and-log-root.md`
+- `.claude/skills/sc-observability-adopting/references/adoption-checklist.md`
+- `.claude/skills/sc-observability-adopting/references/migrate-from-log.md`
+- `.claude/skills/sc-observability-adopting/references/migrate-from-tracing.md`
+- `.claude/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md`
+- `.claude/skills/sc-observability-reviewing/SKILL.md`
+- `.claude/skills/sc-observability-reviewing/references/review-checklist.md`
+- `.claude/skills/sc-observability-reviewing/references/remediation-patterns.md`
+- `.claude/skills/sc-observability-reviewing/references/app-type-guidance.md`
 
 ### 4.2 Marketplace Package
 
@@ -87,21 +87,21 @@ The marketplace package copy will live under `packages/sc-observability/`:
 - `packages/sc-observability/.claude-plugin/plugin.json`
 - `packages/sc-observability/README.md`
 - `packages/sc-observability/CHANGELOG.md`
-- `packages/sc-observability/skills/sc-observability-new-project/SKILL.md`
-- `packages/sc-observability/skills/sc-observability-new-project/references/standard-configuration.md`
-- `packages/sc-observability/skills/sc-observability-new-project/references/console-and-log-root.md`
-- `packages/sc-observability/skills/sc-observability-new-project/assets/observability.rs.j2`
-- `packages/sc-observability/skills/sc-observability-existing-project/SKILL.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/standard-configuration.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/console-and-log-root.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/adoption-checklist.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-log.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-tracing.md`
-- `packages/sc-observability/skills/sc-observability-existing-project/references/migrate-from-custom-jsonl.md`
-- `packages/sc-observability/skills/sc-observability-review/SKILL.md`
-- `packages/sc-observability/skills/sc-observability-review/references/review-checklist.md`
-- `packages/sc-observability/skills/sc-observability-review/references/remediation-patterns.md`
-- `packages/sc-observability/skills/sc-observability-review/references/app-type-guidance.md`
+- `packages/sc-observability/skills/sc-observability-bootstrapping/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-bootstrapping/references/standard-configuration.md`
+- `packages/sc-observability/skills/sc-observability-bootstrapping/references/console-and-log-root.md`
+- `packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2`
+- `packages/sc-observability/skills/sc-observability-adopting/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/standard-configuration.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/console-and-log-root.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/adoption-checklist.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-log.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-tracing.md`
+- `packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md`
+- `packages/sc-observability/skills/sc-observability-reviewing/SKILL.md`
+- `packages/sc-observability/skills/sc-observability-reviewing/references/review-checklist.md`
+- `packages/sc-observability/skills/sc-observability-reviewing/references/remediation-patterns.md`
+- `packages/sc-observability/skills/sc-observability-reviewing/references/app-type-guidance.md`
 
 ### 4.3 Marketplace Metadata
 
@@ -205,7 +205,7 @@ validated against the same Synaptic Canvas architecture guidance.
 
 ## 7. Skill Specifications
 
-### 7.1 `sc-observability-new-project`
+### 7.1 `sc-observability-bootstrapping`
 
 Purpose:
 - help a user set up a new Rust project or repo with `sc-observability` from
@@ -232,6 +232,12 @@ Required references:
 Required asset:
 - `assets/observability.rs.j2`
 
+Required SKILL.md description:
+- include at least two concrete trigger phrases
+- use phrases such as:
+  - "set up sc-observability in a new Rust project"
+  - "add structured logging to a new Rust app"
+
 Required template contents:
 - app-name-based default log root helper
 - home-directory expansion implemented with the recommended `dirs` crate
@@ -243,6 +249,12 @@ Required template contents:
 - explicit indication that the template is rendered through `sc-compose` style
   token substitution and is therefore a generated starter artifact, not a
   static copied file
+- exact token substitution syntax:
+  - Jinja2-style uppercase tokens
+  - `{{APP_NAME}}`
+  - `{{SERVICE_NAME}}`
+  - `{{ENABLE_STDOUT_CONSOLE}}`
+  - `{{ENABLE_STDERR_CONSOLE}}`
 
 Guideline evaluation step for this skill:
 1. review the finished skill against:
@@ -256,7 +268,7 @@ Guideline evaluation step for this skill:
 3. record any required reductions in scope or wording before the skill is
    declared done
 
-### 7.2 `sc-observability-existing-project`
+### 7.2 `sc-observability-adopting`
 
 Purpose:
 - help a user bring `sc-observability` into an existing Rust project without
@@ -265,7 +277,7 @@ Purpose:
 Primary workflow:
 1. inspect the current project shape
 2. decide whether logging-only adoption is enough
-3. apply the same standard configuration convention used by the new-project
+3. apply the same standard configuration convention used by the bootstrapping
    skill
 4. provide an adoption checklist:
    - dependency additions
@@ -284,6 +296,12 @@ Required references:
 - `references/migrate-from-log.md`
 - `references/migrate-from-tracing.md`
 - `references/migrate-from-custom-jsonl.md`
+
+Required SKILL.md description:
+- include at least two concrete trigger phrases
+- use phrases such as:
+  - "bring sc-observability into an existing Rust project"
+  - "adopt sc-observability in a codebase that already has logging"
 
 Scope rule:
 - the skill itself remains focused on adoption into an existing repo
@@ -304,7 +322,7 @@ Guideline evaluation step for this skill:
 3. trim or split content further if the skill body grows beyond a lean
    discovery-layer document
 
-### 7.3 `sc-observability-review`
+### 7.3 `sc-observability-reviewing`
 
 Purpose:
 - review a Rust project's observability setup against the `sc-observability`
@@ -338,6 +356,12 @@ Required references:
 - `references/remediation-patterns.md`
 - `references/app-type-guidance.md`
 
+Required SKILL.md description:
+- include at least two concrete trigger phrases
+- use phrases such as:
+  - "review this project for sc-observability best practices"
+  - "check whether our logging setup matches the sc-observability standard"
+
 Guideline evaluation step for this skill:
 1. review the finished skill against:
    `/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`
@@ -346,7 +370,7 @@ Guideline evaluation step for this skill:
    - checklist details and remediation patterns live in references
    - the `SKILL.md` body stays compact and decision-oriented
    - the output guidance is specific enough to be actionable
-3. revise wording if the skill becomes a generic review skill instead of a
+3. revise wording if the skill becomes a generic reviewing skill instead of a
    focused `sc-observability` review surface
 
 ## 8. Reference Content Plan
@@ -358,6 +382,9 @@ This shared reference must define:
 - the house-style default `~/.<app>` log root
 - the recommended `dirs` crate dependency for home-directory resolution in
   generated starter code
+- explicit acknowledgement that `CONSUMING.md` uses `PathBuf::from("./observability")`
+  as its minimal example while `~/.<app>` is the skill-defined house style on
+  top of that baseline
 - resulting file layout
 - default sinks
 - light logging expectations and boundaries
@@ -392,7 +419,7 @@ This reference must define:
 
 ### 8.4 Migration References
 
-These references are support material for existing-project use cases:
+These references are support material for adopting use cases:
 
 - `migrate-from-log.md`
 - `migrate-from-tracing.md`
@@ -407,13 +434,13 @@ They should explain:
 
 ### 8.5 Review References
 
-These references must support the review skill:
+These references must support the reviewing skill:
 
 - `review-checklist.md`
 - `remediation-patterns.md`
 - `app-type-guidance.md`
 
-They should let the review skill distinguish between:
+They should let the reviewing skill distinguish between:
 
 - a missing baseline
 - a deliberate divergence
@@ -430,13 +457,25 @@ This file must:
 - point the package source to `./packages/sc-observability`
 - include the required package metadata fields described by the Synaptic Canvas
   marketplace guidance
+- enumerate the required plugin fields:
+  - `name`
+  - `source`
+  - `description`
+  - `version`
+  - `author`
+  - `license`
+  - `keywords`
+  - `category`
 
 ### 9.2 `packages/sc-observability/.claude-plugin/plugin.json`
 
 This file must:
 
 - define package name `sc-observability`
-- list the three skill artifacts
+- list the three skill artifacts:
+  - `./skills/sc-observability-bootstrapping/SKILL.md`
+  - `./skills/sc-observability-adopting/SKILL.md`
+  - `./skills/sc-observability-reviewing/SKILL.md`
 - omit commands and agents unless they are intentionally added later
 
 ### 9.3 Package README And Changelog
@@ -492,32 +531,31 @@ sync tooling, but this plan does not require such tooling up front.
 
 ## 11. Implementation Sequence
 
-1. Create this planning document.
-2. Create the minimal marketplace skeleton:
+1. Create the minimal marketplace skeleton:
    - `.claude-plugin/marketplace.json`
    - `packages/sc-observability/.claude-plugin/plugin.json`
    - `packages/sc-observability/README.md`
    - `packages/sc-observability/CHANGELOG.md`
    - `docs/registries/nuget/registry.json`
-3. Create the local skill directories.
-4. Create the marketplace package skill directories.
-5. Write shared reference content:
+2. Create the local skill directories.
+3. Create the marketplace package skill directories.
+4. Write shared reference content:
    - standard configuration
    - console/log-root guidance
    - explicit `dirs`-based home-directory resolution guidance
-6. Write `observability.rs.j2`.
-7. Write `sc-observability-new-project/SKILL.md`.
-8. Evaluate the new-project skill against the Synaptic Canvas skill guidelines
+5. Write `observability.rs.j2`.
+6. Write `sc-observability-bootstrapping/SKILL.md`.
+7. Evaluate the bootstrapping skill against the Synaptic Canvas skill guidelines
    and revise it.
-9. Write existing-project references and `SKILL.md`.
-10. Evaluate the existing-project skill against the Synaptic Canvas skill
+8. Write adopting references and `SKILL.md`.
+9. Evaluate the adopting skill against the Synaptic Canvas skill
     guidelines and revise it.
-11. Write review references and `SKILL.md`.
-12. Evaluate the review skill against the Synaptic Canvas skill guidelines and
+10. Write reviewing references and `SKILL.md`.
+11. Evaluate the reviewing skill against the Synaptic Canvas skill guidelines and
     revise it.
-13. Review both trees for local/package parity.
-14. Validate marketplace metadata for correct package and artifact counts.
-15. Review the full package for completeness and trim any bloated skill bodies.
+12. Review both trees for local/package parity.
+13. Validate marketplace metadata for correct package and artifact counts.
+14. Review the full package for completeness and trim any bloated skill bodies.
 
 ## 12. Plan Review Step
 

--- a/docs/sc-observability-skills-plan.md
+++ b/docs/sc-observability-skills-plan.md
@@ -577,6 +577,41 @@ The review must verify:
 
 If any detail is missing, update this plan before it is committed.
 
+### 12.1 Completion Record
+
+Plan review completion was carried through the implementation loop on
+2026-05-09 in sprint `feature/observability-skill`.
+
+Completed checks:
+
+- all three skills are present in both local and marketplace trees
+- the standard configuration contract is explicit
+- log-root override and console guidance are explicit
+- the template remains part of the shipped skill set
+- migration material stayed references-only in this phase
+- marketplace duplication is implemented and documented
+- metadata files are named explicitly
+- package README and changelog coverage is present
+- per-skill guideline evaluation records are present
+- forwarding limitations remain stated accurately
+
+### 12.2 Parity Check Record
+
+Local and package skill trees were rechecked for parity on 2026-05-09 during
+`impl-fix-1`.
+
+Recorded result:
+
+- `.claude/skills/sc-observability-bootstrapping/` and
+  `packages/sc-observability/skills/sc-observability-bootstrapping/` are
+  identical after mirroring
+- `.claude/skills/sc-observability-adopting/` and
+  `packages/sc-observability/skills/sc-observability-adopting/` are identical
+  after mirroring
+- `.claude/skills/sc-observability-reviewing/` and
+  `packages/sc-observability/skills/sc-observability-reviewing/` are identical
+  after mirroring
+
 ## 13. Exit Criteria
 
 This plan is complete when:

--- a/packages/sc-observability/.claude-plugin/plugin.json
+++ b/packages/sc-observability/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "sc-observability",
+  "description": "Skills for bootstrapping, adopting, and reviewing sc-observability in downstream Rust projects.",
+  "version": "1.0.0",
+  "author": {
+    "name": "randlee"
+  },
+  "license": "MIT",
+  "keywords": [
+    "rust",
+    "observability",
+    "logging",
+    "skills"
+  ],
+  "skills": [
+    "./skills/sc-observability-bootstrapping/SKILL.md",
+    "./skills/sc-observability-adopting/SKILL.md",
+    "./skills/sc-observability-reviewing/SKILL.md"
+  ]
+}

--- a/packages/sc-observability/CHANGELOG.md
+++ b/packages/sc-observability/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0
+
+- initial `sc-observability` marketplace package
+- added `sc-observability-bootstrapping`
+- added `sc-observability-adopting`
+- added `sc-observability-reviewing`

--- a/packages/sc-observability/README.md
+++ b/packages/sc-observability/README.md
@@ -1,0 +1,24 @@
+# sc-observability Marketplace Package
+
+This package contains three Claude Code skills for downstream Rust consumers of
+the published `sc-observability` crates:
+
+- `sc-observability-bootstrapping`
+- `sc-observability-adopting`
+- `sc-observability-reviewing`
+
+These skills are distributed from the `sc-observability` marketplace as an
+independent package.
+
+## Install Model
+
+This marketplace does not forward to Synaptic Canvas. Users who want both
+sources should add both marketplaces separately.
+
+## Package Contents
+
+- bootstrapping guidance
+- adopting guidance
+- reviewing guidance
+- shared references
+- `observability.rs.j2` starter template

--- a/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
@@ -48,3 +48,14 @@ wrapper around the repo's ATM-scoped migration docs.
 - `references/console-and-log-root.md`
 - `references/adoption-checklist.md`
 - migration references as needed
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: migration-specific playbooks stay in `references/`
+  instead of expanding the core skill body

--- a/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sc-observability-adopting
+description: Use when the user says things like "bring sc-observability into an existing Rust project" or "adopt sc-observability in a codebase that already has logging". Adopts sc-observability incrementally with a logging-first path and focused migration references for log, tracing, or custom JSONL setups.
+---
+
+# SC-Observability Adopting
+
+Use this skill when an existing Rust codebase wants to adopt
+`sc-observability`.
+
+## Workflow
+
+1. Inspect the current logging shape first.
+2. Default to a logging-only adoption path before adding routing or OTLP.
+3. Apply the same house style from
+   `references/standard-configuration.md`.
+4. Use `references/adoption-checklist.md` for the step-by-step insertion
+   plan.
+5. Only load migration references when the project already depends on:
+   - `log`
+   - `tracing`
+   - custom JSONL or custom retained logging
+
+## Scope Boundary
+
+This skill is for adopting `sc-observability` into an existing repo.
+
+Library-specific migration detail lives in:
+
+- `references/migrate-from-log.md`
+- `references/migrate-from-tracing.md`
+- `references/migrate-from-custom-jsonl.md`
+
+These files are new writes for this package. Do not treat this skill as a
+wrapper around the repo's ATM-scoped migration docs.
+
+## Required Guidance
+
+- `~/.<app>` remains a house style, not a crate default.
+- Add `sc-observability-types` directly only for custom sinks or shared-type
+  extension work.
+- Preserve stable `target` and `action` naming while replacing existing
+  logging entry points.
+
+## References
+
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+- `references/adoption-checklist.md`
+- migration references as needed

--- a/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/SKILL.md
@@ -56,6 +56,6 @@ Reviewed against
 
 - `SKILL.md` stays concise: confirmed
 - detailed material lives in `references/`: confirmed
-- starter code lives in `assets/`: confirmed
+- no template assets required for this skill: confirmed
 - scope reductions made: migration-specific playbooks stay in `references/`
   instead of expanding the core skill body

--- a/packages/sc-observability/skills/sc-observability-adopting/references/adoption-checklist.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/adoption-checklist.md
@@ -1,0 +1,26 @@
+# Adoption Checklist
+
+## Audit First
+
+- identify the current logging library or custom logger
+- identify current log file paths and operator expectations
+- identify whether console output is part of normal operation
+- identify whether success events already exist for CLI commands
+- identify whether startup and shutdown events already exist for services
+
+## Logging-Only First
+
+Prefer this sequence unless the user explicitly needs more on day one:
+
+1. add `sc-observability`
+2. wire `LoggerConfig::default_for(...)`
+3. adopt the `~/.<app>` house-style root or an explicit override
+4. replace or wrap the current logging entry points
+5. verify the active file path through `logger.health()`
+
+## Incremental Rollout
+
+- replace the highest-value lifecycle and error paths first
+- keep stable `target` and `action` naming from the beginning
+- defer routing and OTLP until logging-only behavior is stable
+- verify downstream log readers or shipping jobs if file paths change

--- a/packages/sc-observability/skills/sc-observability-adopting/references/console-and-log-root.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/console-and-log-root.md
@@ -1,0 +1,53 @@
+# Console And Log Root
+
+## In-Code Log Root Override
+
+The standard setup passes an explicit `log_root` into
+`LoggerConfig::default_for(service, log_root)`.
+
+If the user wants a different default than `~/.<app>`, change that path in the
+app's configuration layer rather than changing the house style itself.
+
+## `SC_LOG_ROOT` Precedence
+
+`LoggerConfig::default_for(...)` uses `SC_LOG_ROOT` only when the provided
+`log_root` is empty.
+
+Practical rule:
+
+- explicit non-empty `log_root` wins
+- empty `log_root` allows `SC_LOG_ROOT` to take effect
+
+## Easiest Console Logging
+
+For simple stdout console logging:
+
+```rust
+config.enable_console_sink = true;
+```
+
+This uses the built-in `ConsoleSink::stdout()` path.
+
+## Stderr Console Logging
+
+If the user wants stderr console output, use `LoggerBuilder` and register
+`ConsoleSink::stderr()` explicitly:
+
+```rust
+use std::sync::Arc;
+
+use sc_observability::{ConsoleSink, LoggerBuilder, SinkRegistration};
+
+config.enable_console_sink = false;
+let mut builder = LoggerBuilder::new(config)?;
+builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+let logger = builder.build();
+```
+
+## Usage Modes
+
+- local development: file + console is often useful
+- long-running production service: file-only is the default baseline
+- CLI: file-only or file + stderr depending on operator preference
+
+Avoid enabling multiple console sinks accidentally.

--- a/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-custom-jsonl.md
@@ -1,0 +1,25 @@
+# Migrate From Custom JSONL
+
+Use this reference when the project already writes its own structured JSONL
+logs or has a custom retained sink pipeline.
+
+## Inventory
+
+- current path layout
+- current schema fields
+- rotation and retention behavior
+- custom health or dropped-event accounting
+
+## Migration Strategy
+
+- compare the current schema with `LogEvent`
+- preserve required operational fields first
+- decide whether custom sink behavior should remain custom or can be replaced
+  by the built-in file sink
+- confirm path compatibility before changing active log locations
+
+## Watch Items
+
+- custom schemas often encode app-specific semantics in ad hoc fields
+- downstream tooling may depend on exact filenames or field names
+- custom health behavior may need explicit remapping to `logger.health()`

--- a/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-log.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-log.md
@@ -1,0 +1,29 @@
+# Migrate From `log`
+
+Use this reference when the existing project is based on `log` macros plus a
+separate logger backend.
+
+## Inventory
+
+- which backend is active now
+- whether file layout is part of operator tooling
+- whether message formatting is structured or plain text
+- where warnings and errors originate today
+
+## Migration Strategy
+
+- replace backend-specific setup with `LoggerConfig::default_for(...)`
+- keep the log root decision explicit
+- introduce stable `target` and `action` names instead of free-form categories
+- migrate the highest-value paths first:
+  - startup
+  - shutdown
+  - warnings
+  - errors
+  - CLI success
+
+## Watch Items
+
+- existing macros may hide category naming drift
+- downstream tooling may assume older file locations
+- plain-text-only logs usually need a deliberate structured field model

--- a/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-tracing.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/migrate-from-tracing.md
@@ -1,0 +1,26 @@
+# Migrate From `tracing`
+
+Use this reference when the existing project already uses `tracing` and
+`tracing-subscriber`.
+
+## Inventory
+
+- existing subscriber stack
+- existing file or console sinks
+- whether traces and logs are already exported remotely
+- whether structured fields already exist and how stable they are
+
+## Migration Strategy
+
+- decide whether the project needs only logging or also needs `sc-observe` and
+  `sc-observability-otlp`
+- preserve lifecycle and error coverage first
+- map tracing metadata into stable `target` and `action` names
+- avoid trying to replace logging, routing, and OTLP in one uncontrolled step
+
+## Watch Items
+
+- tracing setups often mix local logging and telemetry concerns
+- operator expectations may depend on subscriber-specific formatting
+- if OTLP already exists, confirm whether the migration should stop at
+  `sc-observability` first or move straight to the full stack

--- a/packages/sc-observability/skills/sc-observability-adopting/references/standard-configuration.md
+++ b/packages/sc-observability/skills/sc-observability-adopting/references/standard-configuration.md
@@ -1,0 +1,82 @@
+# Standard Configuration
+
+This reference defines the `sc-observability` house style used by these
+skills.
+
+## Scope
+
+This is a skill-defined downstream convention. It is not a built-in
+`sc-observability` crate default.
+
+`CONSUMING.md` shows `PathBuf::from("./observability")` as the minimal crate
+usage example. This skill layers the `~/.<app>` house style on top of that
+baseline for teams that want one consistent convention across apps.
+
+## Recommended Dependencies
+
+```toml
+[dependencies]
+sc-observability = "1"
+serde_json = "1"
+dirs = "6"
+```
+
+Add `sc-observability-types` directly only when:
+
+- implementing custom sinks
+- extending the shared types layer directly
+
+## Default Log Root
+
+Use `~/.<app>` as the default log root convention.
+
+With the built-in file sink, the resulting active file path becomes:
+
+```text
+~/.<app>/logs/<service>.log.jsonl
+```
+
+This works by setting `log_root` to the expanded home-relative directory. The
+crate's actual file layout rule remains:
+
+```text
+<log_root>/logs/<service>.log.jsonl
+```
+
+## Home Directory Expansion
+
+Generated starter code should use the `dirs` crate:
+
+```rust
+dirs::home_dir().map(|p| p.join(format!(".{app}")))
+```
+
+If a home directory cannot be resolved:
+
+- prefer an explicit app-provided path
+- or return a configuration error
+
+Do not silently assume an OS-specific fallback path.
+
+## Light Logging Baseline
+
+- built-in file sink enabled
+- built-in console sink disabled
+- warnings and errors always emitted
+- informational logging remains sparse and intentional
+- long-running apps emit startup and shutdown events
+- CLIs emit one success event per successful command
+- use stable `target` and `action` names
+
+## Runtime Verification
+
+Use `logger.health()` for runtime checks.
+
+At minimum, downstream apps should be able to inspect:
+
+- aggregate logger state
+- active log path
+- sink status
+
+`logger.health().active_log_path` is the standard way to confirm the resolved
+path at runtime.

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/SKILL.md
@@ -52,3 +52,13 @@ style token substitution using:
 - `{{SERVICE_NAME}}`
 - `{{ENABLE_STDOUT_CONSOLE}}`
 - `{{ENABLE_STDERR_CONSOLE}}`
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: none

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: sc-observability-bootstrapping
+description: Use when the user says things like "set up sc-observability in a new Rust project" or "add structured logging to a new Rust app". Bootstraps a new project with sc-observability from crates.io using the shared light-logging house style, ~/.<app> log roots, and a rendered starter template.
+---
+
+# SC-Observability Bootstrapping
+
+Use this skill for new Rust projects or repos that want to start with
+`sc-observability`.
+
+## Workflow
+
+1. Choose the lightest crate set that fits the request:
+   - logging only: `sc-observability`
+   - typed routing: `sc-observe`
+   - OTLP export: `sc-observability-otlp`
+2. Default to logging-only setup unless the user explicitly needs more on day
+   one.
+3. Apply the house style from
+   `references/standard-configuration.md`.
+4. Use `assets/observability.rs.j2` when the user wants starter code or
+   `sc-compose` generation.
+5. Use `references/console-and-log-root.md` for custom roots, console output,
+   and `SC_LOG_ROOT` precedence.
+
+## Required Guidance
+
+- `~/.<app>` is a skill-defined house style, not a crate default.
+- The crate file-layout rule remains `<log_root>/logs/<service>.log.jsonl`.
+- Add `sc-observability-types` directly only when implementing custom sinks or
+  extending the shared types layer.
+- Keep informational logging sparse by default:
+  - warnings and errors always emitted
+  - long-running apps log startup and shutdown
+  - CLIs log one success event per successful command
+
+## References
+
+- `references/standard-configuration.md`
+- `references/console-and-log-root.md`
+- `README.md`
+- `CONSUMING.md`
+
+## Template Asset
+
+- `assets/observability.rs.j2`
+
+The template is a tier-1 rendered starter artifact intended for `sc-compose`
+style token substitution using:
+
+- `{{APP_NAME}}`
+- `{{SERVICE_NAME}}`
+- `{{ENABLE_STDOUT_CONSOLE}}`
+- `{{ENABLE_STDERR_CONSOLE}}`

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -23,7 +23,7 @@ pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
     let log_root = default_log_root()?;
     let mut config = LoggerConfig::default_for(service.clone(), log_root);
 
-    // Only one console token should render true. If both do, stderr wins.
+    // Only one console token should render true. If both render true, stdout takes effect because ENABLE_STDOUT_CONSOLE is evaluated first.
     if ENABLE_STDOUT_CONSOLE {
         config.enable_console_sink = true;
     } else if ENABLE_STDERR_CONSOLE {

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -23,11 +23,10 @@ pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
     let log_root = default_log_root()?;
     let mut config = LoggerConfig::default_for(service.clone(), log_root);
 
+    // Only one console token should render true. If both do, stderr wins.
     if ENABLE_STDOUT_CONSOLE {
         config.enable_console_sink = true;
-    }
-
-    if ENABLE_STDERR_CONSOLE {
+    } else if ENABLE_STDERR_CONSOLE {
         config.enable_console_sink = false;
         let mut builder = LoggerBuilder::new(config)?;
         builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/assets/observability.rs.j2
@@ -1,0 +1,107 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sc_observability::{
+    ActionName, ConsoleSink, Level, LogEvent, Logger, LoggerBuilder, LoggerConfig, OutcomeLabel,
+    ProcessIdentity, SchemaVersion, ServiceName, SinkRegistration, TargetCategory, Timestamp,
+    OBSERVATION_ENVELOPE_VERSION,
+};
+
+const APP_NAME: &str = "{{APP_NAME}}";
+const SERVICE_NAME: &str = "{{SERVICE_NAME}}";
+const ENABLE_STDOUT_CONSOLE: bool = {{ENABLE_STDOUT_CONSOLE}};
+const ENABLE_STDERR_CONSOLE: bool = {{ENABLE_STDERR_CONSOLE}};
+
+pub fn default_log_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    dirs::home_dir()
+        .map(|path| path.join(format!(".{APP_NAME}")))
+        .ok_or_else(|| "could not resolve home directory for default log root".into())
+}
+
+pub fn build_logger() -> Result<Logger, Box<dyn std::error::Error>> {
+    let service = ServiceName::new(SERVICE_NAME)?;
+    let log_root = default_log_root()?;
+    let mut config = LoggerConfig::default_for(service.clone(), log_root);
+
+    if ENABLE_STDOUT_CONSOLE {
+        config.enable_console_sink = true;
+    }
+
+    if ENABLE_STDERR_CONSOLE {
+        config.enable_console_sink = false;
+        let mut builder = LoggerBuilder::new(config)?;
+        builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+        return Ok(builder.build());
+    }
+
+    Ok(Logger::new(config)?)
+}
+
+pub fn emit_service_started(logger: &Logger) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.lifecycle")?,
+        action: ActionName::new("service.started")?,
+        message: Some("service started".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn emit_service_stopping(logger: &Logger) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.lifecycle")?,
+        action: ActionName::new("service.stopping")?,
+        message: Some("service stopping".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn emit_cli_success(logger: &Logger, action_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    logger.emit(LogEvent {
+        version: SchemaVersion::new(OBSERVATION_ENVELOPE_VERSION)?,
+        timestamp: Timestamp::now_utc(),
+        level: Level::Info,
+        service: ServiceName::new(SERVICE_NAME)?,
+        target: TargetCategory::new("app.cli")?,
+        action: ActionName::new(action_name)?,
+        message: Some("command completed successfully".to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(OutcomeLabel::new("ok")?),
+        diagnostic: None,
+        state_transition: None,
+        fields: serde_json::Map::new(),
+    })?;
+    Ok(())
+}
+
+pub fn print_health(logger: &Logger) {
+    let health = logger.health();
+    println!("logger state: {:?}", health.state);
+    println!("active log path: {}", health.active_log_path.display());
+}

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/references/console-and-log-root.md
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/references/console-and-log-root.md
@@ -1,0 +1,53 @@
+# Console And Log Root
+
+## In-Code Log Root Override
+
+The standard setup passes an explicit `log_root` into
+`LoggerConfig::default_for(service, log_root)`.
+
+If the user wants a different default than `~/.<app>`, change that path in the
+app's configuration layer rather than changing the house style itself.
+
+## `SC_LOG_ROOT` Precedence
+
+`LoggerConfig::default_for(...)` uses `SC_LOG_ROOT` only when the provided
+`log_root` is empty.
+
+Practical rule:
+
+- explicit non-empty `log_root` wins
+- empty `log_root` allows `SC_LOG_ROOT` to take effect
+
+## Easiest Console Logging
+
+For simple stdout console logging:
+
+```rust
+config.enable_console_sink = true;
+```
+
+This uses the built-in `ConsoleSink::stdout()` path.
+
+## Stderr Console Logging
+
+If the user wants stderr console output, use `LoggerBuilder` and register
+`ConsoleSink::stderr()` explicitly:
+
+```rust
+use std::sync::Arc;
+
+use sc_observability::{ConsoleSink, LoggerBuilder, SinkRegistration};
+
+config.enable_console_sink = false;
+let mut builder = LoggerBuilder::new(config)?;
+builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+let logger = builder.build();
+```
+
+## Usage Modes
+
+- local development: file + console is often useful
+- long-running production service: file-only is the default baseline
+- CLI: file-only or file + stderr depending on operator preference
+
+Avoid enabling multiple console sinks accidentally.

--- a/packages/sc-observability/skills/sc-observability-bootstrapping/references/standard-configuration.md
+++ b/packages/sc-observability/skills/sc-observability-bootstrapping/references/standard-configuration.md
@@ -1,0 +1,82 @@
+# Standard Configuration
+
+This reference defines the `sc-observability` house style used by these
+skills.
+
+## Scope
+
+This is a skill-defined downstream convention. It is not a built-in
+`sc-observability` crate default.
+
+`CONSUMING.md` shows `PathBuf::from("./observability")` as the minimal crate
+usage example. This skill layers the `~/.<app>` house style on top of that
+baseline for teams that want one consistent convention across apps.
+
+## Recommended Dependencies
+
+```toml
+[dependencies]
+sc-observability = "1"
+serde_json = "1"
+dirs = "6"
+```
+
+Add `sc-observability-types` directly only when:
+
+- implementing custom sinks
+- extending the shared types layer directly
+
+## Default Log Root
+
+Use `~/.<app>` as the default log root convention.
+
+With the built-in file sink, the resulting active file path becomes:
+
+```text
+~/.<app>/logs/<service>.log.jsonl
+```
+
+This works by setting `log_root` to the expanded home-relative directory. The
+crate's actual file layout rule remains:
+
+```text
+<log_root>/logs/<service>.log.jsonl
+```
+
+## Home Directory Expansion
+
+Generated starter code should use the `dirs` crate:
+
+```rust
+dirs::home_dir().map(|p| p.join(format!(".{app}")))
+```
+
+If a home directory cannot be resolved:
+
+- prefer an explicit app-provided path
+- or return a configuration error
+
+Do not silently assume an OS-specific fallback path.
+
+## Light Logging Baseline
+
+- built-in file sink enabled
+- built-in console sink disabled
+- warnings and errors always emitted
+- informational logging remains sparse and intentional
+- long-running apps emit startup and shutdown events
+- CLIs emit one success event per successful command
+- use stable `target` and `action` names
+
+## Runtime Verification
+
+Use `logger.health()` for runtime checks.
+
+At minimum, downstream apps should be able to inspect:
+
+- aggregate logger state
+- active log path
+- sink status
+
+`logger.health().active_log_path` is the standard way to confirm the resolved
+path at runtime.

--- a/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
@@ -50,6 +50,6 @@ Reviewed against
 
 - `SKILL.md` stays concise: confirmed
 - detailed material lives in `references/`: confirmed
-- starter code lives in `assets/`: confirmed
+- no template assets required for this skill: confirmed
 - scope reductions made: remediation examples stay in `references/` so the
   review workflow stays short

--- a/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
@@ -42,3 +42,14 @@ Keep findings concrete. Distinguish:
 - missing baseline
 - deliberate divergence
 - app-type-specific choice
+
+## Guideline Evaluation
+
+Reviewed against
+`/Users/randlee/Documents/github/synaptic-canvas/docs/claude-code-skills-agents-guidelines.md`.
+
+- `SKILL.md` stays concise: confirmed
+- detailed material lives in `references/`: confirmed
+- starter code lives in `assets/`: confirmed
+- scope reductions made: remediation examples stay in `references/` so the
+  review workflow stays short

--- a/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: sc-observability-reviewing
+description: Use when the user says things like "review this project for sc-observability best practices" or "check whether our logging setup matches the sc-observability standard". Reviews a Rust project's observability setup against the shared house style and recommends missing baseline items and easy improvements.
+---
+
+# SC-Observability Reviewing
+
+Use this skill when a user wants a focused review of a Rust project's logging
+or observability setup against the `sc-observability` house style.
+
+## Workflow
+
+1. Determine the app type:
+   - CLI
+   - long-running service
+   - hybrid tool
+2. Load `references/review-checklist.md`.
+3. Use `references/app-type-guidance.md` to adjust expectations by app type.
+4. Use `references/remediation-patterns.md` to turn gaps into concrete
+   recommendations.
+5. Prioritize recommendations:
+   - missing baseline items first
+   - then inconsistent conventions
+   - then optional improvements
+
+## Review Focus
+
+- crates.io adoption surface
+- log root and file path convention
+- override path and environment precedence
+- console setup path
+- warnings/errors coverage
+- service startup/shutdown coverage
+- CLI success-event coverage
+- stable naming for `target` and `action`
+- runtime verification through `logger.health()`
+
+## Output Rule
+
+Keep findings concrete. Distinguish:
+
+- missing baseline
+- deliberate divergence
+- app-type-specific choice

--- a/packages/sc-observability/skills/sc-observability-reviewing/references/app-type-guidance.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/references/app-type-guidance.md
@@ -1,0 +1,27 @@
+# App Type Guidance
+
+## CLI
+
+Expect:
+
+- sparse informational logging
+- one success event per successful command
+- errors and warnings always emitted
+- optional stderr console output for local/operator visibility
+
+## Long-Running Service
+
+Expect:
+
+- startup and shutdown events
+- file sink enabled by default
+- console sink off by default unless local development needs it
+- clear active log path verification
+
+## Hybrid Tool
+
+Expect:
+
+- explicit choice of service-like or CLI-like lifecycle behavior
+- avoid mixing verbose console output with quiet file logging by accident
+- keep target/action naming consistent across both modes

--- a/packages/sc-observability/skills/sc-observability-reviewing/references/remediation-patterns.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/references/remediation-patterns.md
@@ -1,0 +1,36 @@
+# Remediation Patterns
+
+## Missing Default Log Root
+
+Recommend:
+
+- introduce one configuration helper that resolves the app's default root
+- if following house style, use `dirs::home_dir()` and `~/.<app>`
+
+## Missing Console Path
+
+Recommend:
+
+- enable `config.enable_console_sink = true` for simple stdout console logging
+- use `LoggerBuilder` plus `ConsoleSink::stderr()` when stderr is preferred
+
+## Missing Lifecycle Events
+
+Recommend:
+
+- add service startup and shutdown events first
+- add a single CLI success event per successful command path
+
+## No Runtime Verification
+
+Recommend:
+
+- expose `logger.health()` in diagnostics or startup logs
+- inspect `active_log_path` during initialization
+
+## Naming Drift
+
+Recommend:
+
+- normalize `target` to subsystem-style namespaces
+- normalize `action` to stable verbs or lifecycle names

--- a/packages/sc-observability/skills/sc-observability-reviewing/references/review-checklist.md
+++ b/packages/sc-observability/skills/sc-observability-reviewing/references/review-checklist.md
@@ -1,0 +1,33 @@
+# Review Checklist
+
+## Baseline
+
+- `sc-observability` is used when the project wants the shared logging surface
+- `sc-observability-types` is only a direct dependency when actually needed
+- default file sink behavior is understood
+
+## Pathing
+
+- the project defines a default log root convention
+- if following house style, it resolves to `~/.<app>`
+- the resulting active path matches `<log_root>/logs/<service>.log.jsonl`
+- the app can verify the resolved path through `logger.health()`
+
+## Behavior
+
+- warnings and errors are always emitted
+- informational logging is not noisy by default
+- services log startup and shutdown
+- CLIs log one success event per successful command
+
+## Configuration
+
+- the log root can be overridden cleanly
+- `SC_LOG_ROOT` behavior is documented or understood
+- console output is easy to enable intentionally
+
+## Naming
+
+- `service` is stable
+- `target` is subsystem-oriented
+- `action` is stable and searchable


### PR DESCRIPTION
## Summary

- Adds sc-observability skills package (three skills: bootstrapping, adopting, reviewing)
- Local skill tree under `.claude/skills/` and mirrored marketplace package under `packages/sc-observability/`
- Marketplace metadata: `.claude-plugin/marketplace.json`, `packages/sc-observability/.claude-plugin/plugin.json`, tier 1
- Resolves ARCH-001: splits `crates/sc-observability/src/lib.rs` (1019 lines) into `mod runtime`, `mod sinks`, `mod redact` — lib.rs reduced to 277 non-test production lines, zero public API changes

## Skills

| Skill | Purpose |
|---|---|
| `sc-observability-bootstrapping` | Set up sc-observability in a new Rust project |
| `sc-observability-adopting` | Integrate sc-observability into an existing Rust project |
| `sc-observability-reviewing` | Review a project's observability setup against house style |

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] `bash scripts/ci/validate_docs_consistency.sh` passes
- [ ] Local and package skill trees are identical
- [ ] lib.rs public API unchanged (no downstream breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)