### PR TITLE
fix: add User-Agent header to crates.io API curl calls in release-preflight

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -115,7 +115,7 @@ jobs:
           for crate in "${crates[@]}"; do
             url="https://crates.io/api/v1/crates/${crate}"
             response_path="${RUNNER_TEMP}/${crate}.json"
-            status="$(curl --silent --show-error --location --output "$response_path" --write-out '%{http_code}' "$url")"
+            status="$(curl --silent --show-error --location --header "User-Agent: sc-observability-publisher/1.0" --output "$response_path" --write-out '%{http_code}' "$url")"
             case "$status" in
               200)
                 present+=("$crate")


### PR DESCRIPTION
## Summary

- Fixes HTTP 403 from crates.io in `release-preflight.yml` — crates.io rejects requests missing a `User-Agent` header
- Adds `--header "User-Agent: sc-observability-publisher/1.0"` to the curl command in the `Detect initial standalone release mode` step

## Test plan

- [ ] Re-run release-preflight workflow after merge — crates.io query should return 200/404 instead of 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)